### PR TITLE
#903 import jakarta.validation instead of javax.validation 

### DIFF
--- a/embedded-kafka/pom.xml
+++ b/embedded-kafka/pom.xml
@@ -48,8 +48,8 @@
             <artifactId>kafka</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>

--- a/testcontainers-common/pom.xml
+++ b/testcontainers-common/pom.xml
@@ -15,8 +15,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
in order to avoid duplicate classpath entries (jakarta.validation is already pulled transitively)