### PR TITLE
Documentation Neo4j - added missing property embedded.neo4j.host

### DIFF
--- a/embedded-neo4j/README.adoc
+++ b/embedded-neo4j/README.adoc
@@ -24,6 +24,7 @@
 
 * `embedded.neo4j.user`
 * `embedded.neo4j.password`
+* `embedded.neo4j.host`
 * `embedded.neo4j.httpsPort`
 * `embedded.neo4j.httpPort`
 * `embedded.neo4j.boltPort`


### PR DESCRIPTION
In Neo4j README there was one property missing under `Produces` 