### PR TITLE
Fixed aerospike docker image version since is has been archived.

### DIFF
--- a/embedded-aerospike/src/main/java/com/playtika/test/aerospike/AerospikeProperties.java
+++ b/embedded-aerospike/src/main/java/com/playtika/test/aerospike/AerospikeProperties.java
@@ -27,6 +27,6 @@ public class AerospikeProperties extends CommonContainerProperties {
 
     @Override
     public String getDefaultDockerImage() {
-        return "aerospike/aerospike-server:5.7.0.17";
+        return "aerospike/aerospike-server:5.7.0.17-archive";
     }
 }


### PR DESCRIPTION
New image names: https://hub.docker.com/r/aerospike/aerospike-server/tags