### PR TITLE
#1024 update to Azurite 3.20.1

### DIFF
--- a/embedded-azurite/src/main/java/com/playtika/test/azurite/AzuriteProperties.java
+++ b/embedded-azurite/src/main/java/com/playtika/test/azurite/AzuriteProperties.java
@@ -26,6 +26,6 @@ public class AzuriteProperties extends CommonContainerProperties {
 
     @Override
     public String getDefaultDockerImage() {
-        return "mcr.microsoft.com/azure-storage/azurite:3.18.0";
+        return "mcr.microsoft.com/azure-storage/azurite:3.20.1";
     }
 }

--- a/testcontainers-spring-boot-parent/pom.xml
+++ b/testcontainers-spring-boot-parent/pom.xml
@@ -21,7 +21,7 @@
         <spring.cloud.gcp.version>3.2.0</spring.cloud.gcp.version>
         <equalsverifier.version>3.11.1</equalsverifier.version>
         <junit-jupiter.version>5.9.1</junit-jupiter.version>
-        <spring.cloud.azure.version>4.2.0</spring.cloud.azure.version>
+        <spring.cloud.azure.version>4.4.1</spring.cloud.azure.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
This PR fixes https://github.com/PlaytikaOSS/testcontainers-spring-boot/issues/1024 by updating to the latest Azurite Version. I also updated spring-cloud-azure to the latest 4.4 release. Updating to Version 6 of Spring Cloud Azure (which would contain azure blob client 12.20.0) is not possible yet as of https://github.com/PlaytikaOSS/testcontainers-spring-boot/issues/1054 but I tested Azurite 3.20.1 with blob client 12.20.0 in a separate repository and that works fine