### PR TITLE
#1061 Replace SocketUtils with TestSocketUtils

### DIFF
--- a/embedded-redis/src/main/java/com/playtika/test/redis/RedisProperties.java
+++ b/embedded-redis/src/main/java/com/playtika/test/redis/RedisProperties.java
@@ -5,7 +5,7 @@ import com.playtika.test.common.properties.CommonContainerProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.util.SocketUtils;
+import org.springframework.test.util.TestSocketUtils;
 
 import javax.annotation.PostConstruct;
 
@@ -31,7 +31,7 @@ public class RedisProperties extends CommonContainerProperties {
     @PostConstruct
     public void init() {
         if (this.port == 0) {
-            this.port = SocketUtils.findAvailableTcpPort(1025, 50000);
+            this.port = TestSocketUtils.findAvailableTcpPort();
         }
     }
 


### PR DESCRIPTION
 - Fixes #1061 (again).
 - Regression introduced with #1074.
 - #1044 initially fixed #1043 by changing the minimum port passed to `SocketUtils` from 1000 to 1025. #1062 then changed the fix and additionally resolved #1061 by replacing `SocketUtils` with `TestSocketUtils` from spring-test. #1074 then reverted this change reintroducing the dependency to `SocketUtils`.