### PR TITLE
#1084 replace PostConstruct with InitializingBean

### DIFF
--- a/embedded-dynamodb/src/test/java/com/playtika/test/dynamodb/EmbeddedDynamoDBBootstrapConfigurationTest.java
+++ b/embedded-dynamodb/src/test/java/com/playtika/test/dynamodb/EmbeddedDynamoDBBootstrapConfigurationTest.java
@@ -12,14 +12,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanFactoryUtils;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-
-import javax.annotation.PostConstruct;
 
 import java.util.List;
 
@@ -78,7 +77,7 @@ public class EmbeddedDynamoDBBootstrapConfigurationTest {
     @EnableAutoConfiguration
     @Configuration
     @Import(DynamoDBConfig.class)
-    static class TestConfiguration {
+    static class TestConfiguration implements InitializingBean {
 
         @Autowired
         private AmazonDynamoDB amazonDynamoDB;
@@ -86,7 +85,11 @@ public class EmbeddedDynamoDBBootstrapConfigurationTest {
         @Autowired
         private DynamoDBMapper mapper;
 
-        @PostConstruct
+        @Override
+        public void afterPropertiesSet() throws Exception {
+            setupTable();
+        }
+
         void setupTable() throws InterruptedException {
 
             CreateTableRequest ctr = mapper.generateCreateTableRequest(User.class)

--- a/embedded-google-pubsub/src/main/java/com/playtika/test/pubsub/PubSubResourcesGenerator.java
+++ b/embedded-google-pubsub/src/main/java/com/playtika/test/pubsub/PubSubResourcesGenerator.java
@@ -20,14 +20,13 @@ import com.google.pubsub.v1.Topic;
 import com.playtika.test.pubsub.TopicAndSubscription.DeadLetter;
 import io.grpc.ManagedChannel;
 import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.PostConstruct;
+import org.springframework.beans.factory.InitializingBean;
 
 import java.io.IOException;
 import java.util.Collection;
 
 @Slf4j
-public class PubSubResourcesGenerator {
+public class PubSubResourcesGenerator implements InitializingBean {
 
     private final TransportChannelProvider channelProvider;
     private final CredentialsProvider credentialsProvider;
@@ -49,8 +48,8 @@ public class PubSubResourcesGenerator {
         subscriptionAdminClient = subscriptionAdminClient();
     }
 
-    @PostConstruct
-    protected void init() {
+    @Override
+    public void afterPropertiesSet() {
         log.info("Creating topics and subscriptions.");
         topicAndSubscriptions.forEach(this::createTopicAndSubscription);
         log.info("Creating topics and subscriptions created.");

--- a/embedded-google-storage/src/main/java/com/playtika/test/storage/StorageResourcesGenerator.java
+++ b/embedded-google-storage/src/main/java/com/playtika/test/storage/StorageResourcesGenerator.java
@@ -6,13 +6,12 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.playtika.test.storage.StorageProperties.BucketProperties;
 import lombok.extern.slf4j.Slf4j;
-
-import javax.annotation.PostConstruct;
+import org.springframework.beans.factory.InitializingBean;
 
 import java.util.Collection;
 
 @Slf4j
-public class StorageResourcesGenerator {
+public class StorageResourcesGenerator implements InitializingBean {
 
     private final Storage storage;
     private final Collection<BucketProperties> buckets;
@@ -32,9 +31,8 @@ public class StorageResourcesGenerator {
             .getService();
     }
 
-
-    @PostConstruct
-    protected void init() {
+    @Override
+    public void afterPropertiesSet() {
         log.info("Creating buckets.");
         buckets.forEach(this::createBucket);
         log.info("Creating buckets done.");

--- a/embedded-kafka/src/main/java/com/playtika/test/kafka/KafkaTopicsConfigurer.java
+++ b/embedded-kafka/src/main/java/com/playtika/test/kafka/KafkaTopicsConfigurer.java
@@ -6,10 +6,9 @@ import com.playtika.test.kafka.properties.ZookeeperConfigurationProperties;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
-
-import javax.annotation.PostConstruct;
 
 import java.util.Collection;
 import java.util.Map;
@@ -22,15 +21,15 @@ import static java.util.stream.Collectors.toMap;
 @Slf4j
 @RequiredArgsConstructor
 @Getter
-public class KafkaTopicsConfigurer {
+public class KafkaTopicsConfigurer implements InitializingBean {
     private static final int DEFAULT_PARTITION_COUNT = 1;
 
     private final GenericContainer<?> kafka;
     private final ZookeeperConfigurationProperties zookeeperProperties;
     private final KafkaConfigurationProperties kafkaProperties;
 
-    @PostConstruct
-    void configure() {
+    @Override
+    public void afterPropertiesSet() {
         createTopics(this.kafkaProperties.getTopicsToCreate(), this.kafkaProperties.getTopicsConfiguration());
         restrictTopics(KafkaConfigurationProperties.KAFKA_USER, this.kafkaProperties.getSecureTopics());
     }

--- a/embedded-redis/src/main/java/com/playtika/test/redis/RedisProperties.java
+++ b/embedded-redis/src/main/java/com/playtika/test/redis/RedisProperties.java
@@ -5,9 +5,8 @@ import com.playtika.test.common.properties.CommonContainerProperties;
 import com.playtika.test.common.utils.TcpPortAvailableUtils;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-
-import javax.annotation.PostConstruct;
 
 import java.util.Arrays;
 
@@ -16,7 +15,7 @@ import static com.playtika.test.common.utils.TcpPortAvailableUtils.PORT_RANGE_MI
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ConfigurationProperties("embedded.redis")
-public class RedisProperties extends CommonContainerProperties {
+public class RedisProperties extends CommonContainerProperties implements InitializingBean {
     public static final String BEAN_NAME_EMBEDDED_REDIS = "embeddedRedis";
 
     public String user = "root";
@@ -30,8 +29,8 @@ public class RedisProperties extends CommonContainerProperties {
         this.setCapabilities(Arrays.asList(Capability.NET_ADMIN));
     }
 
-    @PostConstruct
-    public void init() {
+    @Override
+    public void afterPropertiesSet() {
         if (this.port == 0) {
             this.port = TcpPortAvailableUtils.findAvailableTcpPort(PORT_RANGE_MIN, 50000);
         }

--- a/testcontainers-common/src/main/java/com/playtika/test/common/utils/PackageInstaller.java
+++ b/testcontainers-common/src/main/java/com/playtika/test/common/utils/PackageInstaller.java
@@ -3,10 +3,9 @@ package com.playtika.test.common.utils;
 import com.playtika.test.common.properties.InstallPackageProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
-
-import javax.annotation.PostConstruct;
 
 /**
  * Instead use ToxiPoxy.
@@ -14,14 +13,18 @@ import javax.annotation.PostConstruct;
 @Slf4j
 @RequiredArgsConstructor
 @Deprecated
-public abstract class PackageInstaller {
+public abstract class PackageInstaller implements InitializingBean {
 
     private final InstallPackageProperties properties;
     private final GenericContainer<?> container;
 
     protected abstract void install(String packageToInstall);
 
-    @PostConstruct
+    @Override
+    public void afterPropertiesSet() {
+        installPackages();
+    }
+
     protected void installPackages() {
         String dockerImageName = container.getDockerImageName();
         String containerName = container.getContainerInfo().getName();


### PR DESCRIPTION
Fixes #1084 by replacing all occurences of `javax.annotation.PostConstruct` with `org.springframework.beans.factory.InitializingBean`