### PR TITLE
log errors in DefaultNetworkTestOperations.withNetworkLatency()

### DIFF
--- a/testcontainers-common/src/main/java/com/playtika/test/common/operations/DefaultNetworkTestOperations.java
+++ b/testcontainers-common/src/main/java/com/playtika/test/common/operations/DefaultNetworkTestOperations.java
@@ -32,6 +32,7 @@ public class DefaultNetworkTestOperations implements NetworkTestOperations {
             addNetworkLatencyForResponses(delay);
             runnable.run();
         } catch (Exception e) {
+            log.error("Failed trying to add network latency", e);
             throw new RuntimeException(e);
         } finally {
             removeNetworkLatencyForResponses();
@@ -44,6 +45,7 @@ public class DefaultNetworkTestOperations implements NetworkTestOperations {
             addNetworkLatencyForResponses(delay);
             return callable.call();
         } catch (Exception e) {
+            log.error("Failed trying to add network latency", e);
             throw new RuntimeException(e);
         } finally {
             removeNetworkLatencyForResponses();


### PR DESCRIPTION
In `DefaultNetworkTestOperations.withNetworkLatency()` If `addNetworkLatencyForResponses()` fails, catch block does not log error and only the subsequent error during `removeNetworkLatencyForResponses()` in the finally block is reported.