### PR TITLE
Update clickhouse/clickhouse-server Docker tag to v23.2.6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,7 @@ updates:
       - "housekeeping"
     schedule:
       interval: "monthly"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/embedded-clickhouse/README.adoc
+++ b/embedded-clickhouse/README.adoc
@@ -16,8 +16,8 @@
 
 * `embedded.clickhouse.enabled` `(true|false, default is true)`
 * `embedded.clickhouse.reuseContainer` `(true|false, default is false)`
-* `embedded.clickhouse.dockerImage` `(default is 'yandex/clickhouse-server:21.7-alpine')`
-** Image versions on https://hub.docker.com/r/yandex/clickhouse-server/tags[dockerhub]
+* `embedded.clickhouse.dockerImage` `(default is 'clickhouse/clickhouse-server:23.2.6')`
+** Image versions on https://hub.docker.com/r/clickhouse/clickhouse-server/tags[dockerhub]
 * `embedded.clickhouse.user` `(default is 'default')`
 * `embedded.clickhouse.password` `(default is '')`
 * `embedded.clickhouse.initScriptPath` `(default is null)`

--- a/embedded-clickhouse/src/main/java/com/playtika/test/clickhouse/ClickHouseProperties.java
+++ b/embedded-clickhouse/src/main/java/com/playtika/test/clickhouse/ClickHouseProperties.java
@@ -19,11 +19,11 @@ public class ClickHouseProperties extends CommonContainerProperties {
     String initScriptPath;
 
     // https://github.com/ClickHouse/ClickHouse/releases
-    // https://hub.docker.com/r/yandex/clickhouse-server
+    // https://hub.docker.com/r/clickhouse/clickhouse-server/tags
     @Override
     public String getDefaultDockerImage() {
         // Please don`t remove this comment.
         // renovate: datasource=docker
-        return "yandex/clickhouse-server:21.7-alpine";
+        return "clickhouse/clickhouse-server:23.2.6";
     }
 }


### PR DESCRIPTION
Motivation:

Use official image

Modification:

Update clickhouse/clickhouse-server Docker tag to v23.2.6

Result:

clickhouse/clickhouse-server Docker tag to v23.2.6