### PR TITLE
Update quay.io/keycloak/keycloak Docker tag to v21.1.1

### DIFF
--- a/embedded-keycloak/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/embedded-keycloak/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -116,7 +116,7 @@
       "name": "embedded.keycloak.docker-image",
       "values": [
         {
-          "value": "quay.io/keycloak/keycloak:21.0.0",
+          "value": "quay.io/keycloak/keycloak:21.1.1",
           "description": "Default Keycloak image in version 21.0.0. Ref https://quay.io/keycloak/keycloak:21.0.0 for further info."
         }
       ]


### PR DESCRIPTION
| datasource | package                   | from   | to     |
| ---------- | ------------------------- | ------ | ------ |
| docker     | quay.io/keycloak/keycloak | 21.0.0 | 21.1.1 |