### PR TITLE
Update prom/prometheus Docker tag to v2.43.0

### DIFF
--- a/embedded-prometheus/README.adoc
+++ b/embedded-prometheus/README.adoc
@@ -16,7 +16,7 @@
 
 * `embedded.prometheus.enabled` `(true|false, default is true)`
 * `embedded.prometheus.reuseContainer` `(true|false, default is false)`
-* `embedded.prometheus.dockerImage` `(default is 'prom/prometheus:v2.42.0')`
+* `embedded.prometheus.dockerImage` `(default is 'prom/prometheus:v2.43.0')`
 ** Image versions on https://hub.docker.com/r/prom/prometheus/tags[dockerhub]
 * `embedded.prometheus.networkAlias` `(default is 'prometheus')`
 * `embedded.toxiproxy.proxies.prometheus.enabled` Enables both creation of the container with ToxiProxy TCP proxy and a proxy to the `embedded-prometheus` container.


### PR DESCRIPTION
| datasource | package         | from    | to      |
| ---------- | --------------- | ------- | ------- |
| docker     | prom/prometheus | v2.42.0 | v2.43.0 |