### PR TITLE
Update releases-docker.jfrog.io/jfrog/artifactory-oss Docker tag to v…

### DIFF
--- a/embedded-artifactory/README.adoc
+++ b/embedded-artifactory/README.adoc
@@ -16,7 +16,7 @@
 
 * `embedded.artifactory.enabled` `(true|false, default is true)`
 * `embedded.artifactory.reuseContainer` `(true|false, default is false)`
-* `embedded.artifactory.dockerImage` `(default is 'releases-docker.jfrog.io/jfrog/artifactory-oss:7.25.6')`
+* `embedded.artifactory.dockerImage` `(default is 'releases-docker.jfrog.io/jfrog/artifactory-oss:7.55.10')`
 ** Release notes on https://www.jfrog.com/confluence/display/JFROG/Artifactory+Release+Notes[jfrog.com]
 * `embedded.artifactory.networkAlias` `(default is 'artifactory')`
 * `embedded.artifactory.username` `(default is 'admin')`


### PR DESCRIPTION
…7.55.10

| datasource | package                                        | from   | to      |
| ---------- | ---------------------------------------------- | ------ | ------- |
| docker     | releases-docker.jfrog.io/jfrog/artifactory-oss | 7.25.6 | 7.55.10 |