### PR TITLE
feat(embedded-opensearch): Allow start with security plugin

### DIFF
--- a/embedded-opensearch/README.adoc
+++ b/embedded-opensearch/README.adoc
@@ -20,6 +20,10 @@
 ** Image versions on https://hub.docker.com/r/opensearchproject/opensearch[docker.opensearch.co]
 * `embedded.opensearch.indices` `(indices to create, no indices are created by default)`
 * `embedded.opensearch.waitTimeoutInSeconds` `(default is 60 seconds)`
+* `embedded.opensearch.credentialsEnabled` `(true|false, default is false)`. Enables start of opensearch with security plugin activated (HTTPS + basic auth).
+* `embedded.opensearch.allowInsecure` (`true|false, default is false)`. Enables TrustAll policy for client methods (for init on startup and wait policies).
+* `embedded.opensearch.username` `(username, default is "admin")`. Login to be sent via basic authentication for client methods (for init on startup and wait policies).
+* `embedded.opensearch.password` `(password, default is "admin")`. Password to be sent via basic authentication for client methods (for init on startup and wait policies).
 * `embedded.toxiproxy.proxies.opensearch.enabled` Enables both creation of the container with ToxiProxy TCP proxy and a proxy to the `embedded-opensearch` container.
 
 

--- a/embedded-opensearch/src/main/java/com/playtika/testcontainer/opensearch/OpenSearchContainerFactory.java
+++ b/embedded-opensearch/src/main/java/com/playtika/testcontainer/opensearch/OpenSearchContainerFactory.java
@@ -11,12 +11,16 @@ import org.testcontainers.containers.wait.strategy.WaitStrategy;
 class OpenSearchContainerFactory {
 
     static OpensearchContainer create(OpenSearchProperties properties) {
-        return new OpensearchContainer(ContainerUtils.getDockerImageName(properties))
+        OpensearchContainer opensearchContainer = new OpensearchContainer(ContainerUtils.getDockerImageName(properties))
                 .withExposedPorts(properties.httpPort, properties.transportPort)
                 .withEnv("cluster.name", properties.getClusterName())
                 .withEnv("discovery.type", "single-node")
                 .withEnv("ES_JAVA_OPTS", getJavaOpts(properties))
                 .waitingFor(getCompositeWaitStrategy(properties));
+        if (properties.isCredentialsEnabled()) {
+            opensearchContainer.withSecurityEnabled();
+        }
+        return opensearchContainer;
     }
 
     private static String getJavaOpts(OpenSearchProperties properties) {

--- a/embedded-opensearch/src/main/java/com/playtika/testcontainer/opensearch/OpenSearchProperties.java
+++ b/embedded-opensearch/src/main/java/com/playtika/testcontainer/opensearch/OpenSearchProperties.java
@@ -20,6 +20,10 @@ public class OpenSearchProperties extends CommonContainerProperties {
     int httpPort = 9200;
     int transportPort = 9300;
     int clusterRamMb = 256;
+    boolean credentialsEnabled = false;
+    boolean allowInsecure = false;
+    String username = "admin";
+    String password = "admin";
 
     // https://hub.docker.com/r/opensearchproject/opensearch
     @Override

--- a/embedded-opensearch/src/main/java/com/playtika/testcontainer/opensearch/rest/CreateIndex.java
+++ b/embedded-opensearch/src/main/java/com/playtika/testcontainer/opensearch/rest/CreateIndex.java
@@ -4,6 +4,9 @@ import com.playtika.testcontainer.common.checks.AbstractInitOnStartupStrategy;
 import com.playtika.testcontainer.opensearch.OpenSearchProperties;
 import lombok.RequiredArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @RequiredArgsConstructor
 public class CreateIndex extends AbstractInitOnStartupStrategy {
 
@@ -12,9 +15,17 @@ public class CreateIndex extends AbstractInitOnStartupStrategy {
 
     @Override
     public String[] getScriptToExecute() {
-        return new String[]{
-            "curl", "-X", "PUT",
-            "http://127.0.0.1:" + properties.getHttpPort() + "/" + index
-        };
+        List<String> command = new ArrayList<>(List.of(
+                "curl", "-X", "PUT", (properties.isCredentialsEnabled() ? "https" : "http") +
+                        "://127.0.0.1:" + properties.getHttpPort() + "/" + index
+        ));
+        if (properties.isCredentialsEnabled()) {
+            command.add("-u");
+            command.add(properties.getUsername() + ':' + properties.getPassword());
+            if (properties.isAllowInsecure()) {
+                command.add("-k");
+            }
+        }
+        return command.toArray(new String[0]);
     }
 }

--- a/embedded-opensearch/src/main/java/com/playtika/testcontainer/opensearch/rest/WaitForGreenStatus.java
+++ b/embedded-opensearch/src/main/java/com/playtika/testcontainer/opensearch/rest/WaitForGreenStatus.java
@@ -4,6 +4,9 @@ import com.playtika.testcontainer.common.checks.AbstractCommandWaitStrategy;
 import com.playtika.testcontainer.opensearch.OpenSearchProperties;
 import lombok.RequiredArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @RequiredArgsConstructor
 public class WaitForGreenStatus extends AbstractCommandWaitStrategy {
 
@@ -11,9 +14,17 @@ public class WaitForGreenStatus extends AbstractCommandWaitStrategy {
 
     @Override
     public String[] getCheckCommand() {
-        return new String[]{
-            "curl", "-X", "GET",
-            "http://127.0.0.1:" + properties.getHttpPort() + "/_cluster/health?wait_for_status=green&timeout=10s"
-        };
+        List<String> command = new ArrayList<>(List.of(
+                "curl", "-X", "GET", (properties.isCredentialsEnabled() ? "https" : "http") +
+                        "://127.0.0.1:" + properties.getHttpPort() + "/_cluster/health?wait_for_status=green&timeout=10s"
+        ));
+        if (properties.isCredentialsEnabled()) {
+            command.add("-u");
+            command.add(properties.getUsername() + ':' + properties.getPassword());
+            if (properties.isAllowInsecure()) {
+                command.add("-k");
+            }
+        }
+        return command.toArray(new String[0]);
     }
 }

--- a/embedded-opensearch/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/embedded-opensearch/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -6,6 +6,26 @@
       "name": "embedded.opensearch.enabled",
       "type": "java.lang.Boolean",
       "defaultValue": "true"
+    },
+    {
+      "name": "embedded.opensearch.credentials-enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": "false"
+    },
+    {
+      "name": "embedded.opensearch.allow-insecure",
+      "type": "java.lang.Boolean",
+      "defaultValue": "false"
+    },
+    {
+      "name": "embedded.opensearch.username",
+      "type": "java.lang.String",
+      "defaultValue": "admin"
+    },
+    {
+      "name": "embedded.opensearch.password",
+      "type": "java.lang.String",
+      "defaultValue": "admin"
     }
   ],
   "hints": [
@@ -19,6 +39,32 @@
         {
           "value": "false",
           "description": "Disables configuration of OpenSearch server on startup."
+        }
+      ]
+    },
+    {
+      "name": "embedded.opensearch.credentials-enabled",
+      "values": [
+        {
+          "value": "true",
+          "description": "Enables security of OpenSearch server on startup (https, credentials needed)."
+        },
+        {
+          "value": "false",
+          "description": "Disables security OpenSearch server on startup (http, no credentials needed)."
+        }
+      ]
+    },
+    {
+      "name": "embedded.opensearch.allow-insecure",
+      "values": [
+        {
+          "value": "true",
+          "description": "Trust all certificates for SSL. Never use this in production."
+        },
+        {
+          "value": "false",
+          "description": "Keep default SSL configuration."
         }
       ]
     }

--- a/embedded-opensearch/src/test/java/com/playtika/testcontainer/opensearch/EmbeddedOpenSearchBootstrapConfigurationTest.java
+++ b/embedded-opensearch/src/test/java/com/playtika/testcontainer/opensearch/EmbeddedOpenSearchBootstrapConfigurationTest.java
@@ -1,27 +1,37 @@
 package com.playtika.testcontainer.opensearch;
 
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.conn.ssl.TrustAllStrategy;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.opensearch.client.RestClientBuilder;
+import org.opensearch.spring.boot.autoconfigure.RestClientBuilderCustomizer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.test.context.ActiveProfiles;
+
+import javax.net.ssl.SSLContext;
+
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ActiveProfiles("enabled")
 @EnableAutoConfiguration(exclude = ElasticsearchDataAutoConfiguration.class)
-@SpringBootTest(
-        classes = EmbeddedOpenSearchBootstrapConfigurationTest.Config.class,
-        properties = {
-                "embedded.opensearch.install.enabled=true"
-        })
 public abstract class EmbeddedOpenSearchBootstrapConfigurationTest {
 
     @Autowired
-    private ConfigurableEnvironment environment;
+    protected ConfigurableEnvironment environment;
 
     @Test
     public void propertiesAreAvailable() {
@@ -35,6 +45,49 @@ public abstract class EmbeddedOpenSearchBootstrapConfigurationTest {
     @EnableAutoConfiguration
     public static class Config {
 
-    }
+        @Bean
+        @Profile("credentials")
+        public RestClientBuilderCustomizer restClientBuilderCustomizer(@NotNull OpenSearchProperties properties) {
+            return new RestClientBuilderCustomizer() {
 
+                @Override
+                public void customize(RestClientBuilder builder) {
+                    builder.setHttpClientConfigCallback(
+                            httpClientBuilder -> {
+                                if (properties.isAllowInsecure()) {
+                                    httpClientBuilder.setSSLContext(sslcontext());
+                                }
+                                return httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider());
+                            }
+                    );
+                }
+
+                @Override
+                public void customize(HttpAsyncClientBuilder builder) {
+                    if (properties.isAllowInsecure()) {
+                        builder.setSSLContext(sslcontext());
+                    }
+                    builder.setDefaultCredentialsProvider(credentialsProvider());
+                }
+
+                CredentialsProvider credentialsProvider() {
+                    final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+                    credentialsProvider.setCredentials(
+                            AuthScope.ANY, new UsernamePasswordCredentials(properties.getUsername(), properties.getPassword())
+                    );
+                    return credentialsProvider;
+                }
+
+                SSLContext sslcontext() {
+                    try {
+                        return SSLContextBuilder.create()
+                                .loadTrustMaterial(null, new TrustAllStrategy())
+                                .build();
+                    } catch (NoSuchAlgorithmException | KeyManagementException | KeyStoreException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            };
+        }
+    }
 }

--- a/embedded-opensearch/src/test/java/com/playtika/testcontainer/opensearch/springdata/SpringDataTest.java
+++ b/embedded-opensearch/src/test/java/com/playtika/testcontainer/opensearch/springdata/SpringDataTest.java
@@ -7,19 +7,27 @@ import org.opensearch.client.RestClient;
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ActiveProfiles("enabled")
+@SpringBootTest(
+        classes = EmbeddedOpenSearchBootstrapConfigurationTest.Config.class,
+        properties = {
+                "embedded.opensearch.enabled=true"
+        })
 public class SpringDataTest extends EmbeddedOpenSearchBootstrapConfigurationTest {
 
     @Autowired
-    private TestDocumentRepository documentRepository;
+    protected TestDocumentRepository documentRepository;
 
     @Autowired
-    private ConfigurableListableBeanFactory beanFactory;
+    protected ConfigurableListableBeanFactory beanFactory;
 
     @Test
     public void springDataShouldWork() {

--- a/embedded-opensearch/src/test/java/com/playtika/testcontainer/opensearch/springdata/SpringDataWithAuthTest.java
+++ b/embedded-opensearch/src/test/java/com/playtika/testcontainer/opensearch/springdata/SpringDataWithAuthTest.java
@@ -1,0 +1,29 @@
+package com.playtika.testcontainer.opensearch.springdata;
+
+import com.playtika.testcontainer.opensearch.EmbeddedOpenSearchBootstrapConfigurationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles(value = "credentials", inheritProfiles = false)
+@SpringBootTest(
+        classes = EmbeddedOpenSearchBootstrapConfigurationTest.Config.class,
+        properties = {
+                "embedded.opensearch.enabled=true",
+                "embedded.opensearch.credentials-enabled=true",
+                "embedded.opensearch.allow-insecure=true"
+        })
+public class SpringDataWithAuthTest extends SpringDataTest {
+
+    @Test
+    public void securityPropertiesAreAvailable() {
+        assertThat(environment.getProperty("embedded.opensearch.credentials-enabled"))
+                .isNotEmpty()
+                .isEqualTo("true");
+        assertThat(environment.getProperty("embedded.opensearch.allow-insecure"))
+                .isNotEmpty()
+                .isEqualTo("true");
+    }
+}

--- a/embedded-opensearch/src/test/resources/application-credentials.properties
+++ b/embedded-opensearch/src/test/resources/application-credentials.properties
@@ -1,0 +1,3 @@
+opensearch.uris=https://${embedded.opensearch.host}:${embedded.opensearch.httpPort}
+opensearch.username=admin
+opensearch.password=admin

--- a/embedded-opensearch/src/test/resources/bootstrap.properties
+++ b/embedded-opensearch/src/test/resources/bootstrap.properties
@@ -1,1 +1,1 @@
-embedded.opensearch.indices=test_index
+embedded.opensearch.indices=test_index,another_one


### PR DESCRIPTION
The OpensearchContainer (from org.opensearch:opensearch-testcontainers) has an option to be started with "security enabled" which is deactivated by default on embedded-opensearch.

This would be quite helpful for me to have the possibility to still rely on embedded-opensearch but with the security plugin enabled.

To be noticed that current docker image relies on a self-signed certificate (when starting with "security enabled"), this enforces to configure the HTTPS connection to have a TrustAll Policy. (That's the reason why in this PR the proposed property has not the same name than inside OpensearchContainer ; calling "security enabled" an option that enforces an SSL TrustAll policy is misleading to me.