### PR TITLE
Add parameters parameter to compiler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                  <parameters>true</parameters>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This change fixes the issue https://github.com/PlaytikaOSS/testcontainers-spring-boot/issues/1627, by doing as instructed in the upgrade guide https://github.com/spring-projects/spring-framework/wiki/Upgrading-to-Spring-Framework-6.x#parameter-name-retention