### PR TITLE
Use IAerospikeClient interface

### DIFF
--- a/embedded-aerospike-enterprise/src/main/java/com/playtika/testcontainers/aerospike/enterprise/EnterpriseAerospikeTestOperationsAutoConfiguration.java
+++ b/embedded-aerospike-enterprise/src/main/java/com/playtika/testcontainers/aerospike/enterprise/EnterpriseAerospikeTestOperationsAutoConfiguration.java
@@ -1,6 +1,6 @@
 package com.playtika.testcontainers.aerospike.enterprise;
 
-import com.aerospike.client.AerospikeClient;
+import com.aerospike.client.IAerospikeClient;
 import com.playtika.testcontainer.aerospike.AerospikeExpiredDocumentsCleaner;
 import com.playtika.testcontainer.aerospike.AerospikeProperties;
 import com.playtika.testcontainer.aerospike.EmbeddedAerospikeTestOperationsAutoConfiguration;
@@ -14,13 +14,13 @@ import org.springframework.context.annotation.Bean;
 @AutoConfiguration(afterName = "org.springframework.boot.autoconfigure.aerospike.AerospikeAutoConfiguration",
         before = EmbeddedAerospikeTestOperationsAutoConfiguration.class)
 @ConditionalOnExpression("${embedded.containers.enabled:true}")
-@ConditionalOnBean({AerospikeClient.class, AerospikeProperties.class})
+@ConditionalOnBean({IAerospikeClient.class, AerospikeProperties.class})
 @ConditionalOnProperty(value = "embedded.aerospike.enabled", matchIfMissing = true)
 public class EnterpriseAerospikeTestOperationsAutoConfiguration {
 
     @Bean
     @ConditionalOnProperty(value = "embedded.aerospike.time-travel.enabled", havingValue = "true", matchIfMissing = true)
-    public ExpiredDocumentsCleaner expiredDocumentsCleaner(AerospikeClient client,
+    public ExpiredDocumentsCleaner expiredDocumentsCleaner(IAerospikeClient client,
                                                            AerospikeProperties properties) {
         return new AerospikeExpiredDocumentsCleaner(client, properties.getNamespace(), true);
     }

--- a/embedded-aerospike-enterprise/src/test/java/com/playtika/testcontainers/aerospike/enterprise/BaseEnterpriseAerospikeTest.java
+++ b/embedded-aerospike-enterprise/src/test/java/com/playtika/testcontainers/aerospike/enterprise/BaseEnterpriseAerospikeTest.java
@@ -1,6 +1,7 @@
 package com.playtika.testcontainers.aerospike.enterprise;
 
 import com.aerospike.client.AerospikeClient;
+import com.aerospike.client.IAerospikeClient;
 import com.aerospike.client.policy.ClientPolicy;
 import com.aerospike.client.policy.WritePolicy;
 import com.playtika.testcontainer.aerospike.AerospikeTestOperations;
@@ -27,7 +28,7 @@ public abstract class BaseEnterpriseAerospikeTest {
     ConfigurableListableBeanFactory beanFactory;
 
     @Autowired
-    AerospikeClient client;
+    IAerospikeClient client;
 
     @Autowired
     WritePolicy writePolicyWithDurableDelete;

--- a/embedded-aerospike/src/main/java/com/playtika/testcontainer/aerospike/AerospikeExpiredDocumentsCleaner.java
+++ b/embedded-aerospike/src/main/java/com/playtika/testcontainer/aerospike/AerospikeExpiredDocumentsCleaner.java
@@ -1,6 +1,6 @@
 package com.playtika.testcontainer.aerospike;
 
-import com.aerospike.client.AerospikeClient;
+import com.aerospike.client.IAerospikeClient;
 import com.aerospike.client.Language;
 import com.aerospike.client.Value;
 import com.aerospike.client.policy.WritePolicy;
@@ -21,11 +21,11 @@ public class AerospikeExpiredDocumentsCleaner implements ExpiredDocumentsCleaner
     private static final int SLEEP_INTERVAL = 100;
     private static final int TIMEOUT = 10_000;
 
-    private final AerospikeClient client;
+    private final IAerospikeClient client;
     private final String namespace;
     private final boolean durableDelete;
 
-    public AerospikeExpiredDocumentsCleaner(AerospikeClient client, String namespace, boolean durableDelete) {
+    public AerospikeExpiredDocumentsCleaner(IAerospikeClient client, String namespace, boolean durableDelete) {
         Assert.notNull(client, "Aerospike client can not be null");
         Assert.notNull(namespace, "Namespace can not be null");
         this.client = client;
@@ -35,7 +35,7 @@ public class AerospikeExpiredDocumentsCleaner implements ExpiredDocumentsCleaner
         registerUdf();
     }
 
-    public AerospikeExpiredDocumentsCleaner(AerospikeClient client, String namespace) {
+    public AerospikeExpiredDocumentsCleaner(IAerospikeClient client, String namespace) {
         this(client, namespace, false);
     }
 

--- a/embedded-aerospike/src/main/java/com/playtika/testcontainer/aerospike/EmbeddedAerospikeBootstrapConfiguration.java
+++ b/embedded-aerospike/src/main/java/com/playtika/testcontainer/aerospike/EmbeddedAerospikeBootstrapConfiguration.java
@@ -1,6 +1,6 @@
 package com.playtika.testcontainer.aerospike;
 
-import com.aerospike.client.AerospikeClient;
+import com.aerospike.client.IAerospikeClient;
 import com.playtika.testcontainer.common.spring.DockerPresenceBootstrapConfiguration;
 import com.playtika.testcontainer.common.utils.ContainerUtils;
 import com.playtika.testcontainer.toxiproxy.EmbeddedToxiProxyBootstrapConfiguration;
@@ -32,7 +32,7 @@ import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCo
 
 @Slf4j
 @Configuration
-@ConditionalOnClass(AerospikeClient.class)
+@ConditionalOnClass(IAerospikeClient.class)
 @ConditionalOnExpression("${embedded.containers.enabled:true}")
 @AutoConfigureAfter({DockerPresenceBootstrapConfiguration.class, EmbeddedToxiProxyBootstrapConfiguration.class})
 @ConditionalOnProperty(value = "embedded.aerospike.enabled", matchIfMissing = true)

--- a/embedded-aerospike/src/main/java/com/playtika/testcontainer/aerospike/EmbeddedAerospikeDependenciesAutoConfiguration.java
+++ b/embedded-aerospike/src/main/java/com/playtika/testcontainer/aerospike/EmbeddedAerospikeDependenciesAutoConfiguration.java
@@ -1,6 +1,6 @@
 package com.playtika.testcontainer.aerospike;
 
-import com.aerospike.client.AerospikeClient;
+import com.aerospike.client.IAerospikeClient;
 import com.playtika.testcontainer.common.spring.DependsOnPostProcessor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
@@ -17,7 +17,7 @@ import static com.playtika.testcontainer.aerospike.AerospikeProperties.BEAN_NAME
 @Slf4j
 @AutoConfiguration
 @AutoConfigureOrder
-@ConditionalOnClass(AerospikeClient.class)
+@ConditionalOnClass(IAerospikeClient.class)
 @ConditionalOnExpression("${embedded.containers.enabled:true}")
 @ConditionalOnProperty(value = "embedded.aerospike.enabled", matchIfMissing = true)
 public class EmbeddedAerospikeDependenciesAutoConfiguration {
@@ -26,7 +26,7 @@ public class EmbeddedAerospikeDependenciesAutoConfiguration {
     protected static class AerospikeClientPostProcessorConfiguration {
         @Bean
         public static BeanFactoryPostProcessor aerospikeClientDependencyPostProcessor() {
-            return new DependsOnPostProcessor(AerospikeClient.class, new String[]{BEAN_NAME_AEROSPIKE});
+            return new DependsOnPostProcessor(IAerospikeClient.class, new String[]{BEAN_NAME_AEROSPIKE});
         }
     }
 }

--- a/embedded-aerospike/src/main/java/com/playtika/testcontainer/aerospike/EmbeddedAerospikeTestOperationsAutoConfiguration.java
+++ b/embedded-aerospike/src/main/java/com/playtika/testcontainer/aerospike/EmbeddedAerospikeTestOperationsAutoConfiguration.java
@@ -1,6 +1,6 @@
 package com.playtika.testcontainer.aerospike;
 
-import com.aerospike.client.AerospikeClient;
+import com.aerospike.client.IAerospikeClient;
 import com.playtika.testcontainer.common.properties.InstallPackageProperties;
 import com.playtika.testcontainer.common.utils.AptGetPackageInstaller;
 import com.playtika.testcontainer.common.utils.PackageInstaller;
@@ -21,7 +21,7 @@ import static com.playtika.testcontainer.aerospike.AerospikeProperties.BEAN_NAME
 
 @AutoConfiguration(afterName = "org.springframework.boot.autoconfigure.aerospike.AerospikeAutoConfiguration")
 @ConditionalOnExpression("${embedded.containers.enabled:true}")
-@ConditionalOnBean({AerospikeClient.class, AerospikeProperties.class})
+@ConditionalOnBean({IAerospikeClient.class, AerospikeProperties.class})
 @ConditionalOnProperty(value = "embedded.aerospike.enabled", matchIfMissing = true)
 public class EmbeddedAerospikeTestOperationsAutoConfiguration {
 
@@ -40,7 +40,7 @@ public class EmbeddedAerospikeTestOperationsAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     @ConditionalOnProperty(value = "embedded.aerospike.time-travel.enabled", havingValue = "true", matchIfMissing = true)
-    public ExpiredDocumentsCleaner expiredDocumentsCleaner(AerospikeClient client,
+    public ExpiredDocumentsCleaner expiredDocumentsCleaner(IAerospikeClient client,
                                                            AerospikeProperties properties) {
         return new AerospikeExpiredDocumentsCleaner(client, properties.getNamespace());
     }

--- a/embedded-aerospike/src/test/java/com/playtika/testcontainer/aerospike/AerospikeExpiredDocumentsCleanerWithDurableDeleteTest.java
+++ b/embedded-aerospike/src/test/java/com/playtika/testcontainer/aerospike/AerospikeExpiredDocumentsCleanerWithDurableDeleteTest.java
@@ -1,6 +1,7 @@
 package com.playtika.testcontainer.aerospike;
 
 import com.aerospike.client.AerospikeClient;
+import com.aerospike.client.IAerospikeClient;
 import com.aerospike.client.Bin;
 import com.aerospike.client.Key;
 import com.aerospike.client.policy.ClientPolicy;
@@ -32,7 +33,7 @@ class AerospikeExpiredDocumentsCleanerWithDurableDeleteTest {
     @Autowired
     ExpiredDocumentsCleaner durableDeleteExpiredDocumentsCleaner;
     @Autowired
-    AerospikeClient aerospikeClient;
+    IAerospikeClient aerospikeClient;
 
     @Test
     public void shouldNotRemoveExpiredWithDurableDeleteFlagBecauseOfAerospikeCommunityEdition() {

--- a/embedded-aerospike/src/test/java/com/playtika/testcontainer/aerospike/AerospikeExpiredDocumentsCleanerWithDurableDeleteTest.java
+++ b/embedded-aerospike/src/test/java/com/playtika/testcontainer/aerospike/AerospikeExpiredDocumentsCleanerWithDurableDeleteTest.java
@@ -1,8 +1,8 @@
 package com.playtika.testcontainer.aerospike;
 
 import com.aerospike.client.AerospikeClient;
-import com.aerospike.client.IAerospikeClient;
 import com.aerospike.client.Bin;
+import com.aerospike.client.IAerospikeClient;
 import com.aerospike.client.Key;
 import com.aerospike.client.policy.ClientPolicy;
 import com.aerospike.client.policy.WritePolicy;

--- a/embedded-aerospike/src/test/java/com/playtika/testcontainer/aerospike/BaseAerospikeTest.java
+++ b/embedded-aerospike/src/test/java/com/playtika/testcontainer/aerospike/BaseAerospikeTest.java
@@ -1,6 +1,7 @@
 package com.playtika.testcontainer.aerospike;
 
 import com.aerospike.client.AerospikeClient;
+import com.aerospike.client.IAerospikeClient;
 import com.aerospike.client.policy.ClientPolicy;
 import com.aerospike.client.policy.WritePolicy;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,11 +31,11 @@ public abstract class BaseAerospikeTest {
     ConfigurableListableBeanFactory beanFactory;
 
     @Autowired
-    AerospikeClient client;
+    IAerospikeClient client;
 
     @Qualifier("aerospikeToxicClient")
     @Autowired
-    AerospikeClient aerospikeToxicClient;
+    IAerospikeClient aerospikeToxicClient;
 
     @Autowired
     WritePolicy policy;

--- a/embedded-aerospike/src/test/java/com/playtika/testcontainer/aerospike/EmbeddedAerospikeBootstrapConfigurationTest.java
+++ b/embedded-aerospike/src/test/java/com/playtika/testcontainer/aerospike/EmbeddedAerospikeBootstrapConfigurationTest.java
@@ -1,8 +1,6 @@
 package com.playtika.testcontainer.aerospike;
 
-import com.aerospike.client.AerospikeClient;
-import com.aerospike.client.Bin;
-import com.aerospike.client.Key;
+import com.aerospike.client.*;
 import com.aerospike.client.Record;
 import com.aerospike.client.policy.Policy;
 import eu.rekawek.toxiproxy.model.ToxicDirection;
@@ -36,10 +34,10 @@ public class EmbeddedAerospikeBootstrapConfigurationTest extends BaseAerospikeTe
     }
 
     @Test
-    public void shouldSetupDependsOnForAerospikeClient() {
-        String[] beanNamesForType = BeanFactoryUtils.beanNamesForTypeIncludingAncestors(beanFactory, AerospikeClient.class);
+    public void shouldSetupDependOnAerospikeClient() {
+        String[] beanNamesForType = BeanFactoryUtils.beanNamesForTypeIncludingAncestors(beanFactory, IAerospikeClient.class);
         assertThat(beanNamesForType)
-                .as("AerospikeClient should be present")
+                .as("IAerospikeClient should be present")
                 .isNotEmpty()
                 .contains("aerospikeClient", "aerospikeToxicClient");
         assertThat(beanNamesForType).allSatisfy(this::hasDependsOn);


### PR DESCRIPTION
There is sense to use beans with IAerospikeClient type because it is a common interface for multiple implementations (currently there are two of them, AerospikeClient and AerospikeClientProxy).