### PR TITLE
docs(rancher/k3s): fix Fabric8 client example

### DIFF
--- a/embedded-k3s/README.adoc
+++ b/embedded-k3s/README.adoc
@@ -46,6 +46,6 @@ https://github.com/fabric8io/kubernetes-client[Fabric8 Java Client]
 ----
 @Bean(destroyMethod = "close")
 public KubernetesClient kubernetesClient(@Value("${embedded.k3s.kubeconfig}") String kubeconfig) {
-    return new KubernetesClientBuilder().withConfig(Config.from(kubeconfig)).build();
+    return new KubernetesClientBuilder().withConfig(Config.fromKubeconfig(kubeconfig)).build();
 }
 ----


### PR DESCRIPTION
Fabric8 Config class has no method "from".

[fromKubeConfig](https://github.com/fabric8io/kubernetes-client/blob/main/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java#L610) is the correct method