### PR TITLE
fix: Replace deprecated LocalStackContainer#getEndpointConfiguration API call

### DIFF
--- a/embedded-localstack/src/main/java/com/playtika/test/localstack/EmbeddedLocalStackBootstrapConfiguration.java
+++ b/embedded-localstack/src/main/java/com/playtika/test/localstack/EmbeddedLocalStackBootstrapConfiguration.java
@@ -57,7 +57,7 @@ public class EmbeddedLocalStackBootstrapConfiguration {
         String prefix = "embedded.localstack.";
         Integer mappedPort = localStack.getMappedPort(properties.getEdgePort());
         for (LocalStackContainer.Service service : properties.services) {
-            map.put(prefix + service, localStack.getEndpointConfiguration(service).getServiceEndpoint());
+            map.put(prefix + service, localStack.getEndpointOverride(service));
             map.put(prefix + service + ".port", mappedPort);
         }
         log.info("Started Localstack. Connection details: {}", map);


### PR DESCRIPTION
Fixes [#1809](https://github.com/PlaytikaOSS/testcontainers-spring-boot/issues/1809)

Replaced `@Deprecated` org.testcontainers API call _([removed](https://github.com/testcontainers/testcontainers-java/pull/5827/commits/d35537e8e1c491d160b26f8619e1b5086f2d0976#diff-da326d6c2ab87885316f4dc5e75ed9b2e1b53e760e36a1a71445f304ece5f136) starting from [v1.18.0](https://github.com/testcontainers/testcontainers-java/releases/tag/1.18.0))_:

- [LocalStackContainer#getEndpointConfiguration](https://github.com/testcontainers/testcontainers-java/blob/1.17.6/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java#L196)

with:

- [LocalStackContainer#getEndpointOverride](https://github.com/testcontainers/testcontainers-java/blob/1.17.6/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java#L200)