### PR TITLE
Add support for Temporal (#2339)

### DIFF
--- a/embedded-temporal/README.adoc
+++ b/embedded-temporal/README.adoc
@@ -1,0 +1,30 @@
+=== embedded-temporal
+
+==== Maven dependency
+
+.pom.xml
+[source,xml]
+----
+<dependency>
+    <groupId>com.playtika.testcontainers</groupId>
+    <artifactId>embedded-temporal</artifactId>
+    <scope>test</scope>
+</dependency>
+----
+
+==== Consumes (via `bootstrap.properties`)
+
+* `embedded.temporal.enabled` `(true|false, default is true)`
+* `embedded.temporal.reuseContainer` `(true|false, default is false)`
+* `embedded.temporal.docker-image` `(default is '1.27')`
+** Image versions on https://hub.docker.com/r/temporalio/admin-tools/tags
+* `embedded.temporal.ui-enabled` `(true|false, default is false)`
+
+==== Produces
+
+* `embedded.temporal.host`
+* `embedded.temporal.port`
+* `embedded.temporal.networkAlias`
+* `embedded.temporal.internalPort`
+* `embedded.temporal.uiPort`
+** When UI is enabled

--- a/embedded-temporal/pom.xml
+++ b/embedded-temporal/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.playtika.testcontainers</groupId>
+        <artifactId>testcontainers-spring-boot-parent</artifactId>
+        <version>3.1.11</version>
+        <relativePath>../testcontainers-spring-boot-parent</relativePath>
+    </parent>
+
+    <artifactId>embedded-temporal</artifactId>
+
+    <properties>
+        <temporal.version>1.29.0</temporal.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.temporal</groupId>
+                <artifactId>temporal-bom</artifactId>
+                <version>${temporal.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.playtika.testcontainers</groupId>
+            <artifactId>testcontainers-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.temporal</groupId>
+            <artifactId>temporal-spring-boot-starter</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/embedded-temporal/src/main/java/com/playtika/testcontainer/temporal/EmbeddedTemporalBootstrapConfiguration.java
+++ b/embedded-temporal/src/main/java/com/playtika/testcontainer/temporal/EmbeddedTemporalBootstrapConfiguration.java
@@ -1,0 +1,97 @@
+package com.playtika.testcontainer.temporal;
+
+import com.playtika.testcontainer.common.spring.DockerPresenceBootstrapConfiguration;
+import com.playtika.testcontainer.common.utils.ContainerUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
+
+import java.util.LinkedHashMap;
+import java.util.Optional;
+
+import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
+import static com.playtika.testcontainer.temporal.TemporalProperties.BEAN_NAME_EMBEDDED_TEMPORAL;
+import static com.playtika.testcontainer.temporal.TemporalProperties.INTERNAL_PORT;
+import static com.playtika.testcontainer.temporal.TemporalProperties.INTERNAL_UI_PORT;
+
+@Slf4j
+@Configuration
+@ConditionalOnExpression("${embedded.containers.enabled:true}")
+@AutoConfigureAfter(DockerPresenceBootstrapConfiguration.class)
+@ConditionalOnProperty(
+        name = "embedded.temporal.enabled",
+        havingValue = "true",
+        matchIfMissing = true)
+@EnableConfigurationProperties(TemporalProperties.class)
+public class EmbeddedTemporalBootstrapConfiguration {
+
+    private static final String TEMPORAL_NETWORK_ALIAS = "temporal.testcontainer.docker";
+
+    @Bean(value = BEAN_NAME_EMBEDDED_TEMPORAL, destroyMethod = "stop")
+    public GenericContainer<?> temporal(ConfigurableEnvironment environment,
+                                        TemporalProperties properties,
+                                        Optional<Network> network) {
+
+        GenericContainer<?> container =
+                new GenericContainer<>(ContainerUtils.getDockerImageName(properties))
+                        .withCreateContainerCmdModifier(cmd -> cmd.withEntrypoint(
+                                "temporal",
+                                "server",
+                                "start-dev"
+                        ))
+                        .withCommand(
+                                "--ip", "0.0.0.0",
+                                "--headless")
+                        .withExposedPorts(INTERNAL_PORT)
+                        .withNetworkAliases(TEMPORAL_NETWORK_ALIAS)
+                        .waitingFor(new HostPortWaitStrategy());
+
+        if (properties.isUiEnabled()) {
+            container
+                    .withCommand("--ip", "0.0.0.0")
+                    .addExposedPort(INTERNAL_UI_PORT);
+        }
+
+        network.ifPresent(container::withNetwork);
+
+        configureCommonsAndStart(container, properties, log);
+
+        registerTemporalEnvironment(container, environment, properties);
+
+        return container;
+    }
+
+    private void registerTemporalEnvironment(GenericContainer<?> container,
+                                             ConfigurableEnvironment environment,
+                                             TemporalProperties properties) {
+
+        String host = container.getHost();
+        Integer port = container.getMappedPort(INTERNAL_PORT);
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.temporal.host", host);
+        map.put("embedded.temporal.port", port);
+        map.put("embedded.temporal.networkAlias", TEMPORAL_NETWORK_ALIAS);
+        map.put("embedded.temporal.internalPort", INTERNAL_PORT);
+
+        log.info("Temporal Server started. Available on: http://{}:{}", host, port);
+
+        if (properties.isUiEnabled()) {
+            Integer uiPort = container.getMappedPort(INTERNAL_UI_PORT);
+            map.put("embedded.temporal.uiPort", uiPort);
+            log.info("Temporal UI started. Available on: http://{}:{}", host, uiPort);
+        }
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedTemporalInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
+    }
+}

--- a/embedded-temporal/src/main/java/com/playtika/testcontainer/temporal/TemporalProperties.java
+++ b/embedded-temporal/src/main/java/com/playtika/testcontainer/temporal/TemporalProperties.java
@@ -1,0 +1,25 @@
+package com.playtika.testcontainer.temporal;
+
+import com.playtika.testcontainer.common.properties.CommonContainerProperties;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ConfigurationProperties("embedded.temporal")
+public class TemporalProperties extends CommonContainerProperties {
+
+    public static final String BEAN_NAME_EMBEDDED_TEMPORAL = "embeddedTemporal";
+    public static final int INTERNAL_PORT = 7233;
+    public static final int INTERNAL_UI_PORT = 8233;
+
+    private boolean uiEnabled;
+
+    @Override
+    public String getDefaultDockerImage() {
+        // Please don`t remove this comment.
+        // renovate: datasource=docker
+        return "temporalio/admin-tools:1.27";
+    }
+}

--- a/embedded-temporal/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/embedded-temporal/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,61 @@
+{
+  "groups": [
+  ],
+  "properties": [
+    {
+      "name": "embedded.temporal.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enables or disables the Temporal container.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "embedded.temporal.docker-image",
+      "type": "java.lang.String",
+      "description": "The Temporal image.",
+      "defaultValue": "1.27"
+    },
+    {
+      "name": "embedded.temporal.ui-enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enables or disables the Temporal UI.",
+      "defaultValue": "false"
+    }
+  ],
+  "hints": [
+    {
+      "name": "embedded.temporal.enabled",
+      "values": [
+        {
+          "value": "true",
+          "description": "Enables the Temporal container."
+        },
+        {
+          "value": "false",
+          "description": "Disables the Temporal container."
+        }
+      ]
+    },
+    {
+      "name": "embedded.temporal.docker-image",
+      "values": [
+        {
+          "value": "1.27",
+          "description": "Default Temporal image Ref https://hub.docker.com/r/temporalio/admin-tools/tags for further info."
+        }
+      ]
+    },
+    {
+      "name": "embedded.temporal.ui-enabled",
+      "values": [
+        {
+          "value": "true",
+          "description": "Enables the Temporal UI."
+        },
+        {
+          "value": "false",
+          "description": "Disables the Temporal UI."
+        }
+      ]
+    }
+  ]
+}

--- a/embedded-temporal/src/main/resources/META-INF/spring.factories
+++ b/embedded-temporal/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.cloud.bootstrap.BootstrapConfiguration=\
+com.playtika.testcontainer.temporal.EmbeddedTemporalBootstrapConfiguration

--- a/embedded-temporal/src/test/java/com/playtika/testcontainer/temporal/EmbeddedTemporalBootstrapConfigurationTest.java
+++ b/embedded-temporal/src/test/java/com/playtika/testcontainer/temporal/EmbeddedTemporalBootstrapConfigurationTest.java
@@ -1,0 +1,144 @@
+package com.playtika.testcontainer.temporal;
+
+import io.temporal.api.history.v1.HistoryEvent;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.testcontainers.containers.Container;
+
+import static io.temporal.api.enums.v1.EventType.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED;
+import static java.util.UUID.randomUUID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+
+class EmbeddedTemporalBootstrapConfigurationTest {
+
+    @SpringBootTest(
+            webEnvironment = WebEnvironment.NONE,
+            classes = EmbeddedTemporalBootstrapConfigurationTest.TestConfiguration.class
+    )
+    @Nested
+    class Headless {
+
+        @Test
+        void workflowExecutionStarts(@Autowired WorkflowClient client) {
+            String workflowId = startWorkflow(client);
+
+            assertThat(client.streamHistory(workflowId.toString()))
+                    .extracting(HistoryEvent::getEventType)
+                    .contains(EVENT_TYPE_WORKFLOW_EXECUTION_STARTED);
+        }
+
+        @Test
+        void uiDisabled(@Autowired Environment environment) {
+            assertThat(environment.getProperty("embedded.temporal.uiPort")).isNull();
+        }
+    }
+
+    @SpringBootTest(
+            webEnvironment = WebEnvironment.NONE,
+            classes = EmbeddedTemporalBootstrapConfigurationTest.TestConfiguration.class,
+            properties = "embedded.temporal.ui-enabled=true"
+    )
+    @Nested
+    class Headed {
+
+        @Test
+        void workflowExecutionStarts(
+                @Autowired WorkflowClient serverClient,
+                @Autowired WebTestClient uiClient) {
+
+            String workflowId = startWorkflow(serverClient);
+
+            uiClient.get().uri("/api/v1/namespaces/default/workflows/{workflowId}/history", workflowId)
+                    .exchange()
+                    .expectStatus().isOk()
+                    .expectBody()
+                    .jsonPath("$.history.events[*].eventType")
+                    .value(hasItem(EVENT_TYPE_WORKFLOW_EXECUTION_STARTED.toString()));
+        }
+    }
+
+    @SpringBootTest(
+            webEnvironment = WebEnvironment.NONE,
+            classes = EmbeddedTemporalBootstrapConfigurationTest.TestConfiguration.class,
+            properties = "embedded.temporal.enabled=false"
+    )
+    @Nested
+    class Disabled {
+
+        @Test
+        void contextLoads(@Autowired ConfigurableApplicationContext context) {
+            assertThat(AssertableApplicationContext.get(() -> context)).hasNotFailed().doesNotHaveBean(Container.class);
+        }
+    }
+
+    @EnableAutoConfiguration
+    @ConditionalOnProperty(name = "embedded.temporal.enabled", havingValue = "true", matchIfMissing = true)
+    @Configuration
+    static class TestConfiguration {
+
+        @Bean
+        WorkflowClient workflowClient(@Value("${embedded.temporal.host}") String host,
+                                      @Value("${embedded.temporal.port}") Integer port) {
+
+            WorkflowServiceStubsOptions options = WorkflowServiceStubsOptions.newBuilder()
+                    .setTarget("%s:%s".formatted(host, port))
+                    .build();
+
+            WorkflowServiceStubs service = WorkflowServiceStubs.newServiceStubs(options);
+
+            return WorkflowClient.newInstance(service);
+        }
+
+        @Bean
+        @ConditionalOnProperty(name = "embedded.temporal.ui-enabled", havingValue = "true")
+        WebTestClient uiClient(@Value("${embedded.temporal.host}") String host,
+                               @Value("${embedded.temporal.uiPort}") Integer uiPort) {
+
+            return WebTestClient.bindToServer()
+                    .baseUrl("http://%s:%s".formatted(host, uiPort))
+                    .build();
+        }
+    }
+
+    String startWorkflow(WorkflowClient client) {
+        Workflow workflow = client.newWorkflowStub(Workflow.class, WorkflowOptions.newBuilder()
+                .setTaskQueue("task-queue")
+                .setWorkflowId(randomUUID().toString())
+                .build());
+
+        return WorkflowClient.start(workflow::execute).getWorkflowId();
+    }
+
+    @WorkflowInterface
+    public interface Workflow {
+
+        @WorkflowMethod
+        void execute();
+    }
+
+    public static class TestWorkflow implements Workflow {
+
+        @Override
+        public void execute() {
+        }
+    }
+}

--- a/embedded-temporal/src/test/resources/log4j2.xml
+++ b/embedded-temporal/src/test/resources/log4j2.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration shutdownHook="disable">
+    <Appenders>
+        <Console name="console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} |%-5p| %c{1}:%L - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="com.playtika.testcontainer" level="info"/>
+        <Logger name="org.springframework" level="error"/>
+        <Root level="error">
+            <AppenderRef ref="console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <module>embedded-mailhog</module>
         <module>embedded-aerospike-enterprise</module>
         <module>embedded-spicedb</module>
+        <module>embedded-temporal</module>
     </modules>
 
     <properties>

--- a/testcontainers-spring-boot-bom/pom.xml
+++ b/testcontainers-spring-boot-bom/pom.xml
@@ -250,6 +250,11 @@
                 <artifactId>embedded-spicedb</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.playtika.testcontainers</groupId>
+                <artifactId>embedded-temporal</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>


### PR DESCRIPTION
Closes #2339

The reason to start a container from a Dockerfile is that Temporal CLI is the only way to start Temporal Server in [development mode](https://docs.temporal.io/cli#start-dev-server) using an in-memory database.
The [existing images](https://hub.docker.com/u/temporalio) expect a preconfigured database.
