### PR TITLE
Embedded Native Kafka

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -267,6 +267,8 @@ embedded:
 
 === link:embedded-kafka/README.adoc[embedded-kafka]
 
+=== link:embedded-native-kafka/README.adoc[embedded-native-kafka]
+
 === link:embedded-rabbitmq/README.adoc[embedded-rabbitmq]
 
 === link:embedded-aerospike/README.adoc[embedded-aerospike]
@@ -377,3 +379,4 @@ embedded:
 ** mailto:sstus@playtika.com[sstus@playtika.com]
 ** mailto:iyova@playtika.com[iyova@playtika.com]
 ** mailto:admitrov@playtika.com[admitrov@playtika.com]
+** mailto:rkvasnytskyi@playtika.com[rkvasnytskyi@playtika.com]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,3 +16,4 @@ If you have the vulnerability report. Please contact with :
 - [sstus@playtika.com](mailto:sstus@playtika.com)
 - [iyova@playtika.com](mailto:iyova@playtika.com)
 - [admitrov@playtika.com](mailto:admitrov@playtika.com)
+- [rkvasnytskyi@playtika.com](mailto:rkvasnytskyi@playtika.com)

--- a/embedded-native-kafka/README.adoc
+++ b/embedded-native-kafka/README.adoc
@@ -1,0 +1,86 @@
+=== embedded-native-kafka
+
+This module provides Apache Kafka Native (GraalVM) support for integration testing using TestContainers.
+The native Kafka image uses KRaft instead of Zookeeper, providing a simpler and more efficient setup.
+
+==== Maven dependency
+
+.pom.xml
+[source,xml]
+----
+<dependency>
+    <groupId>com.playtika.testcontainers</groupId>
+    <artifactId>embedded-native-kafka</artifactId>
+    <scope>test</scope>
+</dependency>
+----
+
+==== Consumes (via `bootstrap.properties`)
+* `embedded.nativekafka.enabled` `(true|false, default is true)`
+* `embedded.nativekafka.topicsToCreate` `(comma separated list of topic names, default is empty)`
+* `embedded.nativekafka.dockerImage` `(default is set to 'apache/kafka-native:4.0.0')`
+** Image versions on https://hub.docker.com/r/apache/kafka-native/tags[dockerhub]
+* `embedded.nativekafka.waitTimeoutInSeconds` `(default is 60 seconds)`
+* `embedded.nativekafka.kafkaPort` `(default is 9092)`
+
+==== Filesystem bindings
+
+Container for `embedded-native-kafka` can bind its volumes to host filesystem.
+By default, to your projects `target` folder. You can configure binding using properties:
+
+* `embedded.nativekafka.fileSystemBind.enabled` `(true|false, default is false)`
+* `embedded.nativekafka.fileSystemBind.dataFolder` `(default : target/embedded-native-kafka-data)`
+
+==== Produces
+
+* `embedded.nativekafka.bootstrapServers`
+* `embedded.nativekafka.brokerList`
+* `embedded.nativekafka.networkAlias`
+* `embedded.nativekafka.host`
+* `embedded.nativekafka.port`
+
+==== Example configuration
+
+.`embedded-native-kafka` configuration (via `bootstrap.properties`)
+[source,properties]
+----
+embedded.nativekafka.topicsToCreate=topic1,topic2
+embedded.nativekafka.fileSystemBind.enabled=true
+----
+
+.Application configuration
+[source,properties]
+----
+# Kafka configuration
+bootstrap.servers=${embedded.nativekafka.bootstrapServers}
+
+# Consumer configuration
+spring.kafka.consumer.bootstrap-servers=${embedded.nativekafka.bootstrapServers}
+spring.kafka.consumer.group-id=test-group
+
+# Producer configuration  
+spring.kafka.producer.bootstrap-servers=${embedded.nativekafka.bootstrapServers}
+----
+
+==== Java usage example
+
+[source,java]
+----
+@SpringBootTest
+class EmbeddedNativeKafkaTest {
+
+    @Autowired
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @Value("${embedded.nativekafka.bootstrapServers}")
+    private String bootstrapServers;
+
+    @Test
+    void testKafkaMessageSendAndReceive() {
+        // Your test logic here
+        kafkaTemplate.send("test-topic", "test-message");
+        
+        // Assert message consumption
+        // ...
+    }
+}

--- a/embedded-native-kafka/pom.xml
+++ b/embedded-native-kafka/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>testcontainers-spring-boot-parent</artifactId>
+        <groupId>com.playtika.testcontainers</groupId>
+        <version>3.1.14</version>
+        <relativePath>../testcontainers-spring-boot-parent</relativePath>
+    </parent>
+
+    <artifactId>embedded-native-kafka</artifactId>
+
+    <properties>
+        <kafka-clients.version>4.0.0</kafka-clients.version>
+        <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-clients</artifactId>
+                <version>${kafka-clients.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.playtika.testcontainers</groupId>
+            <artifactId>testcontainers-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>${maven-clean-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>prepare-tests</id>
+                        <!-- Delete eventual artifacts from previous test mounts -->
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <failOnError>false</failOnError>
+                    <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                    <filesets>
+                        <fileset>
+                            <directory>${java.io.tmpdir}</directory>
+                            <followSymlinks>false</followSymlinks>
+                            <useDefaultExcludes>true</useDefaultExcludes>
+                            <includes>
+                                <include>embedded-native-kafka-*/**</include>
+                            </includes>
+                        </fileset>
+                    </filesets>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/embedded-native-kafka/src/main/java/com/playtika/testcontainer/nativekafka/NativeKafkaTopicsConfigurer.java
+++ b/embedded-native-kafka/src/main/java/com/playtika/testcontainer/nativekafka/NativeKafkaTopicsConfigurer.java
@@ -1,0 +1,80 @@
+package com.playtika.testcontainer.nativekafka;
+
+import com.playtika.testcontainer.nativekafka.properties.NativeKafkaConfigurationProperties;
+import com.playtika.testcontainer.nativekafka.properties.NativeKafkaConfigurationProperties.TopicConfiguration;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.springframework.beans.factory.InitializingBean;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.kafka.KafkaContainer;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toMap;
+
+@Slf4j
+@RequiredArgsConstructor
+@Getter
+public class NativeKafkaTopicsConfigurer implements InitializingBean {
+    private static final int DEFAULT_PARTITION_COUNT = 1;
+
+    private final GenericContainer<?> nativeKafka;
+    private final NativeKafkaConfigurationProperties nativeKafkaProperties;
+
+    @Override
+    public void afterPropertiesSet() {
+        createTopics(this.nativeKafkaProperties.getTopicsToCreate(), this.nativeKafkaProperties.getTopicsConfiguration());
+    }
+
+    public void createTopics(Collection<String> topics, Collection<TopicConfiguration> topicsConfiguration) {
+        Map<String, TopicConfiguration> defaultTopicToTopicConfigurationMap =
+                topics.stream()
+                      .collect(toMap(topic -> topic,
+                                     topic -> new TopicConfiguration(topic, DEFAULT_PARTITION_COUNT)));
+
+        Map<String, TopicConfiguration> topicToTopicConfigurationMap =
+                topicsConfiguration.stream()
+                                   .collect(toMap(TopicConfiguration::getTopic,
+                                                  topicConfiguration -> topicConfiguration));
+
+        defaultTopicToTopicConfigurationMap.putAll(topicToTopicConfigurationMap);
+
+        Collection<TopicConfiguration> topicsConfigurationToCreate = defaultTopicToTopicConfigurationMap.values();
+
+        if (!topicsConfigurationToCreate.isEmpty()) {
+            log.info("Creating Native Kafka topics for configuration: {}", topicsConfigurationToCreate);
+            createTopicsUsingAdminClient(topicsConfigurationToCreate);
+            log.info("Created Native Kafka topics for configuration: {}", topicsConfigurationToCreate);
+        }
+    }
+
+    private void createTopicsUsingAdminClient(Collection<TopicConfiguration> topicsConfigurationToCreate) {
+        Properties adminProps = new Properties();
+        adminProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, ((KafkaContainer) nativeKafka).getBootstrapServers());
+
+        try (AdminClient adminClient = AdminClient.create(adminProps)) {
+            List<NewTopic> newTopics = topicsConfigurationToCreate.stream()
+                    .map(config -> new NewTopic(config.getTopic(), config.getPartitions(), (short) 1))
+                    .collect(Collectors.toList());
+
+            CreateTopicsResult result = adminClient.createTopics(newTopics);
+
+            // Wait for all topics to be created
+            result.all().get();
+            log.debug("Successfully created {} topics using Admin API", newTopics.size());
+        } catch (InterruptedException | ExecutionException e) {
+            log.error("Failed to create topics using Admin API", e);
+            throw new RuntimeException("Failed to create topics", e);
+        }
+    }
+}

--- a/embedded-native-kafka/src/main/java/com/playtika/testcontainer/nativekafka/configuration/EmbeddedNativeKafkaBootstrapConfiguration.java
+++ b/embedded-native-kafka/src/main/java/com/playtika/testcontainer/nativekafka/configuration/EmbeddedNativeKafkaBootstrapConfiguration.java
@@ -1,0 +1,22 @@
+package com.playtika.testcontainer.nativekafka.configuration;
+
+import com.playtika.testcontainer.common.spring.DockerPresenceBootstrapConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureOrder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@AutoConfigureOrder
+@ConditionalOnExpression("${embedded.containers.enabled:true}")
+@AutoConfigureAfter(DockerPresenceBootstrapConfiguration.class)
+public class EmbeddedNativeKafkaBootstrapConfiguration {
+
+    @Import(value = {
+            NativeKafkaContainerConfiguration.class,
+    })
+    @Configuration
+    public static class AllConfigurations {
+    }
+}

--- a/embedded-native-kafka/src/main/java/com/playtika/testcontainer/nativekafka/configuration/EmbeddedNativeKafkaTestOperationsAutoConfiguration.java
+++ b/embedded-native-kafka/src/main/java/com/playtika/testcontainer/nativekafka/configuration/EmbeddedNativeKafkaTestOperationsAutoConfiguration.java
@@ -1,0 +1,36 @@
+package com.playtika.testcontainer.nativekafka.configuration;
+
+import com.playtika.testcontainer.common.properties.InstallPackageProperties;
+import com.playtika.testcontainer.common.utils.PackageInstaller;
+import com.playtika.testcontainer.common.utils.YumPackageInstaller;
+import com.playtika.testcontainer.nativekafka.properties.NativeKafkaConfigurationProperties;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.GenericContainer;
+
+import static com.playtika.testcontainer.nativekafka.properties.NativeKafkaConfigurationProperties.NATIVE_KAFKA_BEAN_NAME;
+import static com.playtika.testcontainer.nativekafka.properties.NativeKafkaConfigurationProperties.NATIVE_KAFKA_PACKAGE_PROPERTIES_BEAN_NAME;
+
+@AutoConfiguration
+@ConditionalOnBean({NativeKafkaConfigurationProperties.class})
+@ConditionalOnExpression("${embedded.containers.enabled:true}")
+@ConditionalOnProperty(value = {"embedded.nativekafka.enabled"}, havingValue = "true", matchIfMissing = true)
+public class EmbeddedNativeKafkaTestOperationsAutoConfiguration {
+
+    @Bean(NATIVE_KAFKA_PACKAGE_PROPERTIES_BEAN_NAME)
+    @ConfigurationProperties("embedded.nativekafka.install")
+    public InstallPackageProperties nativeKafkaPackageProperties() {
+        return new InstallPackageProperties();
+    }
+
+    @Bean
+    public PackageInstaller nativeKafkaPackageInstaller(@Qualifier(NATIVE_KAFKA_PACKAGE_PROPERTIES_BEAN_NAME) InstallPackageProperties nativeKafkaPackageProperties,
+                                                       @Qualifier(NATIVE_KAFKA_BEAN_NAME) GenericContainer<?> nativeKafka) {
+        return new YumPackageInstaller(nativeKafkaPackageProperties, nativeKafka);
+    }
+}

--- a/embedded-native-kafka/src/main/java/com/playtika/testcontainer/nativekafka/configuration/NativeKafkaContainerConfiguration.java
+++ b/embedded-native-kafka/src/main/java/com/playtika/testcontainer/nativekafka/configuration/NativeKafkaContainerConfiguration.java
@@ -1,0 +1,153 @@
+package com.playtika.testcontainer.nativekafka.configuration;
+
+import com.playtika.testcontainer.nativekafka.NativeKafkaTopicsConfigurer;
+import com.playtika.testcontainer.nativekafka.properties.NativeKafkaConfigurationProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
+import static com.playtika.testcontainer.nativekafka.properties.NativeKafkaConfigurationProperties.NATIVE_KAFKA_BEAN_NAME;
+
+@Slf4j
+@Configuration
+@ConditionalOnProperty(value = "embedded.nativekafka.enabled", havingValue = "true", matchIfMissing = true)
+@EnableConfigurationProperties(value = {NativeKafkaConfigurationProperties.class})
+public class NativeKafkaContainerConfiguration {
+
+    public static final String NATIVE_KAFKA_HOST_NAME = "native-kafka-broker.testcontainer.docker";
+
+    @Bean(destroyMethod = "close")
+    @ConditionalOnMissingBean(Network.class)
+    public Network nativeKafkaNetwork() {
+        Network network = Network.newNetwork();
+        log.info("Created docker Network id={}", network.getId());
+        return network;
+    }
+
+    @Bean(name = NATIVE_KAFKA_BEAN_NAME, destroyMethod = "stop")
+    public GenericContainer<?> nativeKafka(
+            NativeKafkaConfigurationProperties nativeKafkaProperties,
+            ConfigurableEnvironment environment,
+            Network network) {
+
+        DockerImageName nativeKafkaImageName = DockerImageName.parse(nativeKafkaProperties.getDefaultDockerImage())
+                .asCompatibleSubstituteFor("confluentinc/cp-kafka");
+
+        KafkaContainer nativeKafka = new KafkaContainer(nativeKafkaImageName)
+                .withNetwork(network)
+                .withNetworkAliases(NATIVE_KAFKA_HOST_NAME)
+                .withExtraHost(NATIVE_KAFKA_HOST_NAME, "127.0.0.1");
+
+        // Configure file system bind if enabled
+        configureFileSystemBind(nativeKafkaProperties, nativeKafka);
+
+        // Configure and start the container using common utilities
+        nativeKafka = (KafkaContainer) configureCommonsAndStart(nativeKafka, nativeKafkaProperties, log);
+
+        // Register environment properties
+        registerNativeKafkaEnvironment(nativeKafka, environment, nativeKafkaProperties);
+
+        return nativeKafka;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public NativeKafkaTopicsConfigurer nativeKafkaTopicsConfigurer(
+            GenericContainer<?> nativeKafka,
+            NativeKafkaConfigurationProperties nativeKafkaProperties) {
+        return new NativeKafkaTopicsConfigurer(nativeKafka, nativeKafkaProperties);
+    }
+
+    private void configureFileSystemBind(NativeKafkaConfigurationProperties nativeKafkaProperties, KafkaContainer nativeKafka) {
+        NativeKafkaConfigurationProperties.FileSystemBind fileSystemBind = nativeKafkaProperties.getFileSystemBind();
+        if (fileSystemBind.isEnabled()) {
+            String currentTimestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("HH-mm-ss-nnnnnnnnn"));
+            String dataFolder = fileSystemBind.getDataFolder();
+            Path kafkaData = Paths.get(dataFolder, currentTimestamp).toAbsolutePath();
+            log.info("Writing native kafka data to: {}", kafkaData);
+            createPathAndParentOrMakeWritable(kafkaData);
+
+            nativeKafka.addFileSystemBind(kafkaData.toString(), "/tmp/kafka-logs", BindMode.READ_WRITE);
+        }
+    }
+
+    private void registerNativeKafkaEnvironment(GenericContainer<?> nativeKafka,
+                                              ConfigurableEnvironment environment,
+                                              NativeKafkaConfigurationProperties nativeKafkaProperties) {
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+
+        String bootstrapServers = ((KafkaContainer) nativeKafka).getBootstrapServers();
+        map.put("embedded.nativekafka.bootstrapServers", bootstrapServers);
+        map.put("embedded.nativekafka.brokerList", bootstrapServers);
+        map.put("embedded.nativekafka.networkAlias", NATIVE_KAFKA_HOST_NAME);
+        map.put("embedded.nativekafka.host", nativeKafka.getHost());
+        map.put("embedded.nativekafka.port", nativeKafka.getMappedPort(nativeKafkaProperties.getKafkaPort()));
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedNativeKafkaInfo", map);
+
+        log.info("Started native kafka broker. Connection details: {}", map);
+
+        environment.getPropertySources().addFirst(propertySource);
+    }
+
+    private void createPathAndParentOrMakeWritable(Path path) {
+        Stream.of(path.getParent(), path).forEach(p -> {
+            if (p != null) {
+                if (p.toFile().isDirectory()) {
+                    makeWritable(p);
+                } else {
+                    try {
+                        log.info("Create writable folder: {}", p);
+                        Files.createDirectory(p, PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwxrwxrwx")));
+                    } catch (FileAlreadyExistsException e) {
+                        makeWritable(p);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        });
+    }
+
+    private void makeWritable(Path path) {
+        PosixFileAttributeView fileAttributeView = Files.getFileAttributeView(path, PosixFileAttributeView.class);
+        if (fileAttributeView == null) {
+            log.warn("Couldn't get file permissions: {}", path);
+            return;
+        }
+        try {
+            Set<PosixFilePermission> permissions = fileAttributeView.readAttributes().permissions();
+            if (permissions.add(PosixFilePermission.OTHERS_WRITE)) {
+                log.info("Make writable to others: {}", path);
+                fileAttributeView.setPermissions(permissions);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/embedded-native-kafka/src/main/java/com/playtika/testcontainer/nativekafka/properties/NativeKafkaConfigurationProperties.java
+++ b/embedded-native-kafka/src/main/java/com/playtika/testcontainer/nativekafka/properties/NativeKafkaConfigurationProperties.java
@@ -1,0 +1,61 @@
+package com.playtika.testcontainer.nativekafka.properties;
+
+import com.github.dockerjava.api.model.Capability;
+import com.playtika.testcontainer.common.properties.CommonContainerProperties;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.With;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ConfigurationProperties("embedded.nativekafka")
+public class NativeKafkaConfigurationProperties extends CommonContainerProperties {
+
+    public static final String NATIVE_KAFKA_BEAN_NAME = "nativeKafka";
+    public static final String NATIVE_KAFKA_PACKAGE_PROPERTIES_BEAN_NAME = "nativeKafkaPackageProperties";
+
+    protected String bootstrapServers;
+    protected int kafkaPort = 9092;
+    protected int socketTimeoutMs = 5_000;
+    protected int bufferSize = 64 * 1024;
+
+    protected Collection<String> topicsToCreate = Collections.emptyList();
+    protected Collection<TopicConfiguration> topicsConfiguration = Collections.emptyList();
+
+    protected FileSystemBind fileSystemBind = new FileSystemBind();
+
+    public NativeKafkaConfigurationProperties() {
+        this.setCapabilities(Arrays.asList(Capability.NET_ADMIN));
+    }
+
+    @Override
+    public String getDefaultDockerImage() {
+        // Please don`t remove this comment.
+        // renovate: datasource=docker
+        return "apache/kafka-native:4.0.0";
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Data
+    @With
+    public static final class FileSystemBind {
+        private boolean enabled = false;
+        private String dataFolder = "target/embedded-native-kafka-data";
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Data
+    public static final class TopicConfiguration {
+        private String topic;
+        private int partitions;
+    }
+}

--- a/embedded-native-kafka/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/embedded-native-kafka/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,26 @@
+{
+  "groups": [
+  ],
+  "properties": [
+    {
+      "name": "embedded.nativekafka.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": "true"
+    }
+  ],
+  "hints": [
+    {
+      "name": "embedded.nativekafka.enabled",
+      "values": [
+        {
+          "value": "true",
+          "description": "Enables configuration of native kafka cluster on startup."
+        },
+        {
+          "value": "false",
+          "description": "Disabled configuration of native kafka cluster on startup."
+        }
+      ]
+    }
+  ]
+}

--- a/embedded-native-kafka/src/main/resources/META-INF/spring.factories
+++ b/embedded-native-kafka/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.cloud.bootstrap.BootstrapConfiguration=\
+com.playtika.testcontainer.nativekafka.configuration.EmbeddedNativeKafkaBootstrapConfiguration

--- a/embedded-native-kafka/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/embedded-native-kafka/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.playtika.testcontainer.nativekafka.configuration.EmbeddedNativeKafkaTestOperationsAutoConfiguration

--- a/embedded-native-kafka/src/test/java/com/playtika/testcontainer/nativekafka/AbstractEmbeddedNativeKafkaTest.java
+++ b/embedded-native-kafka/src/test/java/com/playtika/testcontainer/nativekafka/AbstractEmbeddedNativeKafkaTest.java
@@ -1,0 +1,281 @@
+package com.playtika.testcontainer.nativekafka;
+
+import com.playtika.testcontainer.common.utils.ThrowingRunnable;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.DescribeTopicsResult;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.assertj.core.util.Lists;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.ISOLATION_LEVEL_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.ACKS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.BATCH_SIZE_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION;
+import static org.apache.kafka.clients.producer.ProducerConfig.RETRIES_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.TRANSACTIONAL_ID_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(
+        properties = {
+                "embedded.nativekafka.topicsToCreate=topic1,topic2,topic3",
+                "embedded.nativekafka.topicsConfiguration[0].topic=topic3",
+                "embedded.nativekafka.topicsConfiguration[0].partitions=2"
+        },
+        classes = {AbstractEmbeddedNativeKafkaTest.TestConfiguration.class}
+)
+public abstract class AbstractEmbeddedNativeKafkaTest {
+
+    @Autowired
+    protected AdminClient adminClient;
+    @Value("${embedded.nativekafka.bootstrapServers}")
+    protected List<String> nativeKafkaBrokerList;
+
+    protected void sendMessage(String topic, String message) throws Exception {
+        try (KafkaProducer<String, String> kafkaProducer = createProducer()) {
+            kafkaProducer.send(new ProducerRecord<>(topic, message)).get();
+        }
+    }
+
+    protected void sendTransactionalMessage(String topic, String message) throws Exception {
+        try (KafkaProducer<String, String> kafkaProducer = createTransactionalProducer()) {
+            kafkaProducer.beginTransaction();
+            kafkaProducer.send(new ProducerRecord<>(topic, message)).get();
+            kafkaProducer.commitTransaction();
+        }
+    }
+
+    protected void sendMessage(String topic, String message, Map<String, Object> producerConfiguration) throws Exception {
+        try (KafkaProducer<String, String> kafkaProducer = createProducer(producerConfiguration)) {
+            kafkaProducer.send(new ProducerRecord<>(topic, message)).get();
+        }
+    }
+
+    protected String consumeMessage(String topic) {
+        return consumeMessages(topic)
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("no message received"));
+    }
+
+    protected String consumeMessage(String topic, Map<String, Object> consumerConfiguration) {
+        return consumeMessages(topic, consumerConfiguration)
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("no message received"));
+    }
+
+    protected String consumeTransactionalMessage(String topic) {
+        return consumeMessagesTransactional(topic)
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("no message received"));
+    }
+
+    protected List<String> consumeMessages(String topic) {
+        return consumeMessages(topic, getNativeKafkaConsumerConfiguration());
+    }
+
+    protected List<String> consumeMessagesTransactional(String topic) {
+        try (KafkaConsumer<String, String> consumer = createTransactionalConsumer(topic)) {
+            return pollForRecords(consumer)
+                    .stream()
+                    .map(ConsumerRecord::value)
+                    .collect(Collectors.toList());
+        }
+    }
+
+    protected List<String> consumeMessages(String topic, Map<String, Object> consumerConfiguration) {
+        try (KafkaConsumer<String, String> consumer = createConsumer(topic, consumerConfiguration)) {
+            return pollForRecords(consumer)
+                    .stream()
+                    .map(ConsumerRecord::value)
+                    .collect(Collectors.toList());
+        }
+    }
+
+    protected KafkaProducer<String, String> createProducer() {
+        return createProducer(getNativeKafkaProducerConfiguration());
+    }
+
+    protected KafkaProducer<String, String> createTransactionalProducer() {
+        KafkaProducer<String, String> kafkaProducer = createProducer(getNativeKafkaTransactionalProducerConfiguration());
+        kafkaProducer.initTransactions();
+        return kafkaProducer;
+    }
+
+    protected KafkaProducer<String, String> createProducer(Map<String, Object> producerConfiguration) {
+        return new KafkaProducer<>(producerConfiguration);
+    }
+
+    protected KafkaConsumer<String, String> createConsumer(String topic) {
+        return createConsumer(topic, getNativeKafkaConsumerConfiguration());
+    }
+
+    protected KafkaConsumer<String, String> createTransactionalConsumer(String topic) {
+        return createConsumer(topic, getNativeKafkaTransactionalConsumerConfiguration());
+    }
+
+    protected KafkaConsumer<String, String> createConsumer(String topic, Map<String, Object> consumerConfiguration) {
+        Properties properties = new Properties();
+        Map<String, Object> config = new HashMap<>(getNativeKafkaConsumerConfiguration());
+        config.putAll(consumerConfiguration);
+        properties.putAll(config);
+        KafkaConsumer<String, String> consumer = new KafkaConsumer<>(properties);
+        consumer.subscribe(singleton(topic));
+        return consumer;
+    }
+
+    protected void assertThatTopicExists(String topic) {
+        try {
+            DescribeTopicsResult describeTopicsResult = adminClient.describeTopics(singleton(topic));
+            Map<String, KafkaFuture<TopicDescription>> topicNameValues = describeTopicsResult.topicNameValues();
+            assertThat(topicNameValues).containsKey(topic);
+            TopicDescription topicDescription = topicNameValues.get(topic).get(30, TimeUnit.SECONDS);
+            assertThat(topicDescription).isNotNull();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected void assertThatTopicExists(String topicName, int partitions) throws Exception {
+        DescribeTopicsResult describeTopics = adminClient.describeTopics(Collections.singletonList(topicName));
+        Map<String, KafkaFuture<TopicDescription>>  topicNameValues = describeTopics.topicNameValues();
+
+        assertThat(topicNameValues).containsKey(topicName);
+        TopicDescription topicDescription = topicNameValues.get(topicName).get(5, TimeUnit.SECONDS);
+
+        assertThat(topicDescription).isNotNull();
+        assertThat(topicDescription.partitions().size()).isEqualTo(partitions);
+    }
+
+    protected void assertThatTopicHasPartitions(String topic, int partitions) {
+        try {
+            DescribeTopicsResult describeTopicsResult = adminClient.describeTopics(singleton(topic));
+            Map<String, KafkaFuture<TopicDescription>> topicNameValues = describeTopicsResult.topicNameValues();
+            assertThat(topicNameValues).containsKey(topic);
+            TopicDescription topicDescription = topicNameValues.get(topic).get(30, TimeUnit.SECONDS);
+            assertThat(topicDescription.partitions()).hasSize(partitions);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected static <K, V> List<ConsumerRecord<K, V>> pollForRecords(KafkaConsumer<K, V> consumer) {
+        ConsumerRecords<K, V> received = consumer.poll(Duration.ofSeconds(10));
+        return received == null ? emptyList() : Lists.newArrayList(received);
+    }
+
+    protected Map<String, Object> getNativeKafkaProducerConfiguration() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, nativeKafkaBrokerList);
+        configs.put(KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        configs.put(VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        configs.put(RETRIES_CONFIG, 0);
+        configs.put(BATCH_SIZE_CONFIG, 0);
+        return configs;
+    }
+
+    protected Map<String, Object> getNativeKafkaTransactionalProducerConfiguration() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, nativeKafkaBrokerList);
+        configs.put(KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        configs.put(VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        configs.put(BATCH_SIZE_CONFIG, 0);
+        configs.put(TRANSACTIONAL_ID_CONFIG, "tx-0");
+        configs.put(MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);
+        configs.put(ENABLE_IDEMPOTENCE_CONFIG, true);
+        configs.put(ACKS_CONFIG, "all");
+        configs.put(RETRIES_CONFIG, 10);
+        configs.put(DELIVERY_TIMEOUT_MS_CONFIG, 300000);
+        configs.put(ProducerConfig.RETRY_BACKOFF_MS_CONFIG, 1000);
+        return configs;
+    }
+
+    protected Map<String, Object> getNativeKafkaConsumerConfiguration() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, nativeKafkaBrokerList);
+        configs.put(GROUP_ID_CONFIG, "testGroup");
+        configs.put(AUTO_OFFSET_RESET_CONFIG, "earliest");
+        configs.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        configs.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        return configs;
+    }
+
+    protected Map<String, Object> getNativeKafkaTransactionalConsumerConfiguration() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, nativeKafkaBrokerList);
+        configs.put(GROUP_ID_CONFIG, "testGroup");
+        configs.put(AUTO_OFFSET_RESET_CONFIG, "earliest");
+        configs.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        configs.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        configs.put(ISOLATION_LEVEL_CONFIG, "read_committed");
+        configs.put(ENABLE_AUTO_COMMIT_CONFIG, false);
+        return configs;
+    }
+
+    protected static long durationOf(ThrowingRunnable operation) throws Exception {
+        long startTimestamp = System.currentTimeMillis();
+        operation.run();
+        return System.currentTimeMillis() - startTimestamp;
+    }
+
+    protected static Path projectDir() throws Exception {
+        URI classesPath = AbstractEmbeddedNativeKafkaTest.class
+                .getProtectionDomain()
+                .getCodeSource()
+                .getLocation()
+                .toURI();
+        return Paths.get(classesPath).getParent().getParent();
+    }
+
+    @EnableAutoConfiguration
+    @Configuration
+    static class TestConfiguration {
+
+        @Bean
+        public AdminClient adminClient(@Value("${embedded.nativekafka.bootstrapServers}") String nativeKafkaBrokerList) {
+            Properties config = new Properties();
+            config.put(BOOTSTRAP_SERVERS_CONFIG, nativeKafkaBrokerList);
+            return AdminClient.create(config);
+        }
+    }
+}

--- a/embedded-native-kafka/src/test/java/com/playtika/testcontainer/nativekafka/DisableNativeKafkaTest.java
+++ b/embedded-native-kafka/src/test/java/com/playtika/testcontainer/nativekafka/DisableNativeKafkaTest.java
@@ -1,0 +1,32 @@
+package com.playtika.testcontainer.nativekafka;
+
+import com.playtika.testcontainer.nativekafka.configuration.EmbeddedNativeKafkaBootstrapConfiguration;
+import com.playtika.testcontainer.nativekafka.configuration.EmbeddedNativeKafkaTestOperationsAutoConfiguration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Order(1)
+@DisplayName("Test that application")
+public class DisableNativeKafkaTest {
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    EmbeddedNativeKafkaBootstrapConfiguration.class,
+                    EmbeddedNativeKafkaTestOperationsAutoConfiguration.class));
+
+    @Test
+    @DisplayName("runs with native kafka disabled")
+    public void contextLoads() {
+        contextRunner
+                .withPropertyValues(
+                        "embedded.nativekafka.enabled=false"
+                )
+                .run((context) -> assertThat(context)
+                        .hasNotFailed()
+                        .doesNotHaveBean("nativeKafka"));
+    }
+}

--- a/embedded-native-kafka/src/test/java/com/playtika/testcontainer/nativekafka/EmbeddedNativeKafkaTest.java
+++ b/embedded-native-kafka/src/test/java/com/playtika/testcontainer/nativekafka/EmbeddedNativeKafkaTest.java
@@ -1,0 +1,97 @@
+package com.playtika.testcontainer.nativekafka;
+
+import com.playtika.testcontainer.nativekafka.properties.NativeKafkaConfigurationProperties;
+import com.playtika.testcontainer.nativekafka.properties.NativeKafkaConfigurationProperties.TopicConfiguration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@Order(2)
+@TestPropertySource(properties = {
+    "embedded.nativekafka.fileSystemBind.dataFolder=${java.io.tmpdir}/embedded-native-kafka-data-unexpected"
+})
+@TestInstance(PER_CLASS)
+@DisplayName("Default embedded-native-kafka setup test")
+public class EmbeddedNativeKafkaTest extends AbstractEmbeddedNativeKafkaTest {
+
+    private static final String MESSAGE = "test message";
+
+    @Autowired
+    protected NativeKafkaTopicsConfigurer nativeKafkaTopicsConfigurer;
+
+    @Test
+    @DisplayName("creates topics on startup")
+    public void shouldAutoCreateTopic() throws Exception {
+        assertThatTopicExists("topic1", 1);
+        assertThatTopicExists("topic3", 2);
+    }
+
+    @Test
+    @DisplayName("allows to create other topics")
+    public void shouldCreateTopic() throws Exception {
+        String topicToCreate = "topicToCreate";
+        int defaultPartitions = 1;
+        String topicToCreate1 = "topicToCreate1";
+        int customPartitions = 2;
+
+        nativeKafkaTopicsConfigurer.createTopics(java.util.Collections.singletonList(topicToCreate),
+                                               java.util.Collections.singletonList(new TopicConfiguration(topicToCreate1, customPartitions)));
+
+        assertThatTopicExists(topicToCreate, defaultPartitions);
+        assertThatTopicExists(topicToCreate1, customPartitions);
+    }
+
+    @Test
+    @DisplayName("allows send and consume messages")
+    public void shouldSendAndConsumeMessage() throws Exception {
+        sendMessage("topic1", MESSAGE);
+
+        String consumedMessage = consumeMessage("topic1");
+
+        assertThat(consumedMessage)
+                .isEqualTo(MESSAGE);
+    }
+
+    @Test
+    @DisplayName("provides bootstrap servers configuration")
+    public void shouldProvideBootstrapServers() {
+        assertThat(nativeKafkaBrokerList)
+                .isNotEmpty()
+                .allMatch(broker -> broker.contains(":"));
+    }
+
+    @Test
+    @DisplayName("allows send and consume transactional messages")
+    public void shouldSendAndConsumeTransactionalMessage() throws Exception {
+        sendTransactionalMessage("topic2", MESSAGE);
+
+        String consumedMessage = consumeTransactionalMessage("topic2");
+
+        assertThat(consumedMessage)
+                .isEqualTo(MESSAGE);
+    }
+
+    @AfterAll
+    public static void afterAll(@Autowired NativeKafkaConfigurationProperties nativeKafkaProperties, TestInfo testInfo) throws Exception {
+        // JUnit invokes static afterAll() even when child class is running and TestInstance.Lifecycle.PER_CLASS is being used
+        if (!testInfo.getTestClass().map(EmbeddedNativeKafkaTest.class::equals).orElse(false)) {
+            return;
+        }
+
+        Path projectDir = projectDir();
+        Path nativeKafkaDataFolder = projectDir.resolve(nativeKafkaProperties.getFileSystemBind().getDataFolder());
+
+        assertThat(nativeKafkaDataFolder.toFile()).doesNotExist();
+    }
+
+}

--- a/embedded-native-kafka/src/test/java/com/playtika/testcontainer/nativekafka/EmbeddedNativeKafkaWithBindingTest.java
+++ b/embedded-native-kafka/src/test/java/com/playtika/testcontainer/nativekafka/EmbeddedNativeKafkaWithBindingTest.java
@@ -1,0 +1,56 @@
+package com.playtika.testcontainer.nativekafka;
+
+import com.playtika.testcontainer.nativekafka.properties.NativeKafkaConfigurationProperties;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.test.context.TestPropertySource;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.PathUtils;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static com.playtika.testcontainer.nativekafka.properties.NativeKafkaConfigurationProperties.NATIVE_KAFKA_BEAN_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Order(6)
+@TestPropertySource(properties = {
+    "embedded.nativekafka.waitTimeoutInSeconds=120",
+    "embedded.nativekafka.fileSystemBind.enabled=true",
+    "embedded.nativekafka.fileSystemBind.dataFolder=${java.io.tmpdir}/embedded-native-kafka-data" // /tmp is more permissible than target
+})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("Test that embedded-native-kafka with filesystem binding")
+public class EmbeddedNativeKafkaWithBindingTest extends EmbeddedNativeKafkaTest {
+
+    @AfterAll
+    public static void afterAll(@Autowired NativeKafkaConfigurationProperties nativeKafkaProperties, @Qualifier(NATIVE_KAFKA_BEAN_NAME) GenericContainer<?> nativeKafka) throws Exception {
+        Path projectDir = projectDir();
+        Path nativeKafkaDataFolder = projectDir.resolve(nativeKafkaProperties.getFileSystemBind().getDataFolder());
+
+        assertThat(nativeKafkaDataFolder.toFile()).isNotEmptyDirectory();
+
+        // Delete created files now
+        nativeKafka.execInContainer("rm", "-rf", "/tmp/kafka-logs");
+
+        // Delete mounted directories after test run
+        Runtime.getRuntime().addShutdownHook(new Thread(DockerClientFactory.TESTCONTAINERS_THREAD_GROUP, () -> {
+            PathUtils.recursiveDeleteDir(nativeKafkaDataFolder);
+        }));
+    }
+
+    protected static Path projectDir() {
+        try {
+            URI projectDirUri = EmbeddedNativeKafkaWithBindingTest.class.getClassLoader().getResource("").toURI();
+            return Paths.get(projectDirUri).getParent().getParent();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/embedded-native-kafka/src/test/java/com/playtika/testcontainer/nativekafka/NativeKafkaTopicsConfigurerTest.java
+++ b/embedded-native-kafka/src/test/java/com/playtika/testcontainer/nativekafka/NativeKafkaTopicsConfigurerTest.java
@@ -1,0 +1,280 @@
+package com.playtika.testcontainer.nativekafka;
+
+import com.playtika.testcontainer.nativekafka.properties.NativeKafkaConfigurationProperties;
+import com.playtika.testcontainer.nativekafka.properties.NativeKafkaConfigurationProperties.TopicConfiguration;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.errors.TopicExistsException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.testcontainers.kafka.KafkaContainer;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NativeKafkaTopicsConfigurer Tests")
+class NativeKafkaTopicsConfigurerTest {
+
+    @Mock
+    private KafkaContainer nativeKafka;
+
+    @Mock
+    private NativeKafkaConfigurationProperties properties;
+
+    @Mock
+    private AdminClient adminClient;
+
+    @Mock
+    private CreateTopicsResult createTopicsResult;
+
+    @Mock
+    private KafkaFuture<Void> future;
+
+    @Captor
+    private ArgumentCaptor<Collection<NewTopic>> newTopicsCaptor;
+
+    private NativeKafkaTopicsConfigurer configurer;
+
+    @BeforeEach
+    void setUp() {
+        configurer = new NativeKafkaTopicsConfigurer(nativeKafka, properties);
+    }
+
+    @Test
+    @DisplayName("afterPropertiesSet should call createTopics with configuration from properties")
+    void shouldCallCreateTopicsOnAfterPropertiesSet() {
+        Collection<String> topicsToCreate = Collections.emptyList();
+        Collection<TopicConfiguration> topicsConfiguration = Collections.emptyList();
+
+        when(properties.getTopicsToCreate()).thenReturn(topicsToCreate);
+        when(properties.getTopicsConfiguration()).thenReturn(topicsConfiguration);
+
+        configurer.afterPropertiesSet();
+
+        verify(properties).getTopicsToCreate();
+        verify(properties).getTopicsConfiguration();
+    }
+
+    @Test
+    @DisplayName("should create topics with default partitions when no custom configuration provided")
+    void shouldCreateTopicsWithDefaultPartitions() {
+        when(nativeKafka.getBootstrapServers()).thenReturn("localhost:9092");
+
+        try (MockedStatic<AdminClient> adminClientMock = mockStatic(AdminClient.class)) {
+            adminClientMock.when(() -> AdminClient.create(any(Properties.class))).thenReturn(adminClient);
+            when(adminClient.createTopics(anyCollection())).thenReturn(createTopicsResult);
+            when(createTopicsResult.all()).thenReturn(future);
+
+            Collection<String> topicsToCreate = Arrays.asList("topic1", "topic2");
+            Collection<TopicConfiguration> topicsConfiguration = Collections.emptyList();
+
+            configurer.createTopics(topicsToCreate, topicsConfiguration);
+
+            verify(adminClient).createTopics(newTopicsCaptor.capture());
+            Collection<NewTopic> createdTopics = newTopicsCaptor.getValue();
+
+            assertThat(createdTopics).hasSize(2);
+            assertThat(createdTopics).extracting(NewTopic::name).containsExactlyInAnyOrder("topic1", "topic2");
+            assertThat(createdTopics).extracting(NewTopic::numPartitions).allMatch(partitions -> partitions == 1);
+        }
+    }
+
+    @Test
+    @DisplayName("should create topics with custom partitions when configuration provided")
+    void shouldCreateTopicsWithCustomPartitions() {
+        when(nativeKafka.getBootstrapServers()).thenReturn("localhost:9092");
+
+        try (MockedStatic<AdminClient> adminClientMock = mockStatic(AdminClient.class)) {
+            adminClientMock.when(() -> AdminClient.create(any(Properties.class))).thenReturn(adminClient);
+            when(adminClient.createTopics(anyCollection())).thenReturn(createTopicsResult);
+            when(createTopicsResult.all()).thenReturn(future);
+
+            Collection<String> topicsToCreate = Arrays.asList("topic1");
+            Collection<TopicConfiguration> topicsConfiguration = Arrays.asList(
+                    new TopicConfiguration("topic1", 5),
+                    new TopicConfiguration("topic2", 3)
+            );
+
+            configurer.createTopics(topicsToCreate, topicsConfiguration);
+
+            verify(adminClient).createTopics(newTopicsCaptor.capture());
+            Collection<NewTopic> createdTopics = newTopicsCaptor.getValue();
+
+            assertThat(createdTopics).hasSize(2);
+
+            NewTopic topic1 = createdTopics.stream()
+                    .filter(topic -> "topic1".equals(topic.name()))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(topic1.numPartitions()).isEqualTo(5);
+
+            NewTopic topic2 = createdTopics.stream()
+                    .filter(topic -> "topic2".equals(topic.name()))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(topic2.numPartitions()).isEqualTo(3);
+        }
+    }
+
+    @Test
+    @DisplayName("should merge topics to create with custom configuration, prioritizing custom config")
+    void shouldMergeTopicsWithCustomConfigurationTakingPrecedence() {
+        when(nativeKafka.getBootstrapServers()).thenReturn("localhost:9092");
+
+        try (MockedStatic<AdminClient> adminClientMock = mockStatic(AdminClient.class)) {
+            adminClientMock.when(() -> AdminClient.create(any(Properties.class))).thenReturn(adminClient);
+            when(adminClient.createTopics(anyCollection())).thenReturn(createTopicsResult);
+            when(createTopicsResult.all()).thenReturn(future);
+
+            Collection<String> topicsToCreate = Arrays.asList("topic1", "topic2");
+            Collection<TopicConfiguration> topicsConfiguration = Arrays.asList(
+                    new TopicConfiguration("topic1", 10)
+            );
+
+            configurer.createTopics(topicsToCreate, topicsConfiguration);
+
+            verify(adminClient).createTopics(newTopicsCaptor.capture());
+            Collection<NewTopic> createdTopics = newTopicsCaptor.getValue();
+
+            assertThat(createdTopics).hasSize(2);
+
+            NewTopic topic1 = createdTopics.stream()
+                    .filter(topic -> "topic1".equals(topic.name()))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(topic1.numPartitions()).isEqualTo(10);
+
+            NewTopic topic2 = createdTopics.stream()
+                    .filter(topic -> "topic2".equals(topic.name()))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(topic2.numPartitions()).isEqualTo(1);
+        }
+    }
+
+    @Test
+    @DisplayName("should not create topics when both collections are empty")
+    void shouldNotCreateTopicsWhenEmpty() {
+        try (MockedStatic<AdminClient> adminClientMock = mockStatic(AdminClient.class)) {
+            configurer.createTopics(Collections.emptyList(), Collections.emptyList());
+
+            adminClientMock.verify(() -> AdminClient.create(any(Properties.class)), never());
+            verify(adminClient, never()).createTopics(anyCollection());
+        }
+    }
+
+    @Test
+    @DisplayName("should handle execution exception during topic creation")
+    void shouldHandleExecutionExceptionDuringTopicCreation() throws Exception {
+        when(nativeKafka.getBootstrapServers()).thenReturn("localhost:9092");
+
+        try (MockedStatic<AdminClient> adminClientMock = mockStatic(AdminClient.class)) {
+            adminClientMock.when(() -> AdminClient.create(any(Properties.class))).thenReturn(adminClient);
+            when(adminClient.createTopics(anyCollection())).thenReturn(createTopicsResult);
+            when(createTopicsResult.all()).thenReturn(future);
+            when(future.get()).thenThrow(new ExecutionException(new TopicExistsException("Topic exists")));
+
+            Collection<String> topicsToCreate = Arrays.asList("topic1");
+            Collection<TopicConfiguration> topicsConfiguration = Collections.emptyList();
+
+            assertThatThrownBy(() -> configurer.createTopics(topicsToCreate, topicsConfiguration))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("Failed to create topics")
+                    .hasCauseInstanceOf(ExecutionException.class);
+        }
+    }
+
+    @Test
+    @DisplayName("should handle interrupted exception during topic creation")
+    void shouldHandleInterruptedExceptionDuringTopicCreation() throws Exception {
+        when(nativeKafka.getBootstrapServers()).thenReturn("localhost:9092");
+
+        try (MockedStatic<AdminClient> adminClientMock = mockStatic(AdminClient.class)) {
+            adminClientMock.when(() -> AdminClient.create(any(Properties.class))).thenReturn(adminClient);
+            when(adminClient.createTopics(anyCollection())).thenReturn(createTopicsResult);
+            when(createTopicsResult.all()).thenReturn(future);
+            when(future.get()).thenThrow(new InterruptedException("Interrupted"));
+
+            Collection<String> topicsToCreate = Arrays.asList("topic1");
+            Collection<TopicConfiguration> topicsConfiguration = Collections.emptyList();
+
+            assertThatThrownBy(() -> configurer.createTopics(topicsToCreate, topicsConfiguration))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("Failed to create topics")
+                    .hasCauseInstanceOf(InterruptedException.class);
+        }
+    }
+
+    @Test
+    @DisplayName("should create topics with replication factor of 1")
+    void shouldCreateTopicsWithReplicationFactorOne() {
+        when(nativeKafka.getBootstrapServers()).thenReturn("localhost:9092");
+
+        try (MockedStatic<AdminClient> adminClientMock = mockStatic(AdminClient.class)) {
+            adminClientMock.when(() -> AdminClient.create(any(Properties.class))).thenReturn(adminClient);
+            when(adminClient.createTopics(anyCollection())).thenReturn(createTopicsResult);
+            when(createTopicsResult.all()).thenReturn(future);
+
+            Collection<String> topicsToCreate = Arrays.asList("topic1");
+            Collection<TopicConfiguration> topicsConfiguration = Collections.emptyList();
+
+            configurer.createTopics(topicsToCreate, topicsConfiguration);
+
+            verify(adminClient).createTopics(newTopicsCaptor.capture());
+            Collection<NewTopic> createdTopics = newTopicsCaptor.getValue();
+
+            assertThat(createdTopics).hasSize(1);
+            NewTopic topic = createdTopics.iterator().next();
+            assertThat(topic.replicationFactor()).isEqualTo((short) 1);
+        }
+    }
+
+    @Test
+    @DisplayName("should only create topics from configuration when no topics to create specified")
+    void shouldCreateOnlyConfiguredTopicsWhenNoTopicsToCreateSpecified() {
+        when(nativeKafka.getBootstrapServers()).thenReturn("localhost:9092");
+
+        try (MockedStatic<AdminClient> adminClientMock = mockStatic(AdminClient.class)) {
+            adminClientMock.when(() -> AdminClient.create(any(Properties.class))).thenReturn(adminClient);
+            when(adminClient.createTopics(anyCollection())).thenReturn(createTopicsResult);
+            when(createTopicsResult.all()).thenReturn(future);
+
+            Collection<String> topicsToCreate = Collections.emptyList();
+            Collection<TopicConfiguration> topicsConfiguration = Arrays.asList(
+                    new TopicConfiguration("configuredTopic", 2)
+            );
+
+            configurer.createTopics(topicsToCreate, topicsConfiguration);
+
+            verify(adminClient).createTopics(newTopicsCaptor.capture());
+            Collection<NewTopic> createdTopics = newTopicsCaptor.getValue();
+
+            assertThat(createdTopics).hasSize(1);
+            NewTopic topic = createdTopics.iterator().next();
+            assertThat(topic.name()).isEqualTo("configuredTopic");
+            assertThat(topic.numPartitions()).isEqualTo(2);
+        }
+    }
+}

--- a/embedded-native-kafka/src/test/java/com/playtika/testcontainer/nativekafka/configuration/NativeKafkaContainerConfigurationTest.java
+++ b/embedded-native-kafka/src/test/java/com/playtika/testcontainer/nativekafka/configuration/NativeKafkaContainerConfigurationTest.java
@@ -1,0 +1,287 @@
+package com.playtika.testcontainer.nativekafka.configuration;
+
+import com.playtika.testcontainer.nativekafka.NativeKafkaTopicsConfigurer;
+import com.playtika.testcontainer.nativekafka.properties.NativeKafkaConfigurationProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MutablePropertySources;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.kafka.KafkaContainer;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NativeKafkaContainerConfiguration Tests")
+class NativeKafkaContainerConfigurationTest {
+
+    @Mock
+    private NativeKafkaConfigurationProperties properties;
+
+    @Mock
+    private ConfigurableEnvironment environment;
+
+    @Mock
+    private Network network;
+
+    @Mock
+    private KafkaContainer kafkaContainer;
+
+    @Mock
+    private GenericContainer<?> genericContainer;
+
+    @Mock
+    private MutablePropertySources mutablePropertySources;
+
+    @TempDir
+    private Path tempDir;
+
+    private NativeKafkaContainerConfiguration configuration;
+
+    @BeforeEach
+    void setUp() {
+        configuration = new NativeKafkaContainerConfiguration();
+    }
+
+    @Test
+    @DisplayName("should create network with proper configuration")
+    void shouldCreateNetworkWithProperConfiguration() {
+        Network network = configuration.nativeKafkaNetwork();
+
+        assertThat(network).isNotNull();
+        assertThat(network.getId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("should create kafka container with proper docker image and network configuration")
+    void shouldCreateKafkaContainerWithProperConfiguration() {
+        when(environment.getPropertySources()).thenReturn(mutablePropertySources);
+        when(properties.getDefaultDockerImage()).thenReturn("apache/kafka-native:4.0.0");
+        when(properties.getFileSystemBind()).thenReturn(new NativeKafkaConfigurationProperties.FileSystemBind());
+        when(properties.getKafkaPort()).thenReturn(9092);
+
+        try (MockedStatic<com.playtika.testcontainer.common.utils.ContainerUtils> containerUtilsMock =
+                mockStatic(com.playtika.testcontainer.common.utils.ContainerUtils.class)) {
+
+            containerUtilsMock.when(() -> configureCommonsAndStart(any(KafkaContainer.class), eq(properties), any()))
+                    .thenReturn(kafkaContainer);
+
+            when(kafkaContainer.getBootstrapServers()).thenReturn("localhost:9092");
+            when(kafkaContainer.getHost()).thenReturn("localhost");
+            when(kafkaContainer.getMappedPort(9092)).thenReturn(9092);
+
+            GenericContainer<?> result = configuration.nativeKafka(properties, environment, network);
+
+            assertThat(result).isEqualTo(kafkaContainer);
+            containerUtilsMock.verify(() -> configureCommonsAndStart(any(KafkaContainer.class), eq(properties), any()));
+        }
+    }
+
+    @Test
+    @DisplayName("should configure file system bind when enabled")
+    void shouldConfigureFileSystemBindWhenEnabled() throws IOException {
+        NativeKafkaConfigurationProperties.FileSystemBind fileSystemBind =
+                new NativeKafkaConfigurationProperties.FileSystemBind(true, tempDir.toString());
+
+        when(environment.getPropertySources()).thenReturn(mutablePropertySources);
+        when(properties.getDefaultDockerImage()).thenReturn("apache/kafka-native:4.0.0");
+        when(properties.getFileSystemBind()).thenReturn(fileSystemBind);
+        when(properties.getKafkaPort()).thenReturn(9092);
+
+        try (MockedStatic<com.playtika.testcontainer.common.utils.ContainerUtils> containerUtilsMock =
+                mockStatic(com.playtika.testcontainer.common.utils.ContainerUtils.class)) {
+
+            containerUtilsMock.when(() -> configureCommonsAndStart(any(KafkaContainer.class), eq(properties), any()))
+                    .thenReturn(kafkaContainer);
+
+            when(kafkaContainer.getBootstrapServers()).thenReturn("localhost:9092");
+            when(kafkaContainer.getHost()).thenReturn("localhost");
+            when(kafkaContainer.getMappedPort(9092)).thenReturn(9092);
+
+            GenericContainer<?> result = configuration.nativeKafka(properties, environment, network);
+
+            assertThat(result).isEqualTo(kafkaContainer);
+
+            assertThat(Files.list(tempDir))
+                    .anyMatch(path -> path.getFileName().toString().matches("\\d{2}-\\d{2}-\\d{2}-\\d{9}"));
+        }
+    }
+
+    @Test
+    @DisplayName("should not configure file system bind when disabled")
+    void shouldNotConfigureFileSystemBindWhenDisabled() {
+        NativeKafkaConfigurationProperties.FileSystemBind fileSystemBind =
+                new NativeKafkaConfigurationProperties.FileSystemBind(false, tempDir.toString());
+
+        when(environment.getPropertySources()).thenReturn(mutablePropertySources);
+        when(properties.getDefaultDockerImage()).thenReturn("apache/kafka-native:4.0.0");
+        when(properties.getFileSystemBind()).thenReturn(fileSystemBind);
+        when(properties.getKafkaPort()).thenReturn(9092);
+
+        try (MockedStatic<com.playtika.testcontainer.common.utils.ContainerUtils> containerUtilsMock =
+                mockStatic(com.playtika.testcontainer.common.utils.ContainerUtils.class)) {
+
+            containerUtilsMock.when(() -> configureCommonsAndStart(any(KafkaContainer.class), eq(properties), any()))
+                    .thenReturn(kafkaContainer);
+
+            when(kafkaContainer.getBootstrapServers()).thenReturn("localhost:9092");
+            when(kafkaContainer.getHost()).thenReturn("localhost");
+            when(kafkaContainer.getMappedPort(9092)).thenReturn(9092);
+
+            GenericContainer<?> result = configuration.nativeKafka(properties, environment, network);
+
+            assertThat(result).isEqualTo(kafkaContainer);
+            assertThat(Files.exists(tempDir.resolve("embedded-native-kafka-data"))).isFalse();
+        }
+    }
+
+    @Test
+    @DisplayName("should register environment properties correctly")
+    void shouldRegisterEnvironmentPropertiesCorrectly() {
+        when(environment.getPropertySources()).thenReturn(mutablePropertySources);
+        when(properties.getDefaultDockerImage()).thenReturn("apache/kafka-native:4.0.0");
+        when(properties.getFileSystemBind()).thenReturn(new NativeKafkaConfigurationProperties.FileSystemBind());
+        when(properties.getKafkaPort()).thenReturn(9092);
+
+        try (MockedStatic<com.playtika.testcontainer.common.utils.ContainerUtils> containerUtilsMock =
+                mockStatic(com.playtika.testcontainer.common.utils.ContainerUtils.class)) {
+
+            containerUtilsMock.when(() -> configureCommonsAndStart(any(KafkaContainer.class), eq(properties), any()))
+                    .thenReturn(kafkaContainer);
+
+            when(kafkaContainer.getBootstrapServers()).thenReturn("localhost:9092");
+            when(kafkaContainer.getHost()).thenReturn("localhost");
+            when(kafkaContainer.getMappedPort(9092)).thenReturn(12345);
+
+            configuration.nativeKafka(properties, environment, network);
+
+            verify(environment).getPropertySources();
+        }
+    }
+
+    @Test
+    @DisplayName("should create native kafka topics configurer bean")
+    void shouldCreateNativeKafkaTopicsConfigurerBean() {
+        NativeKafkaTopicsConfigurer result = configuration.nativeKafkaTopicsConfigurer(genericContainer, properties);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getNativeKafka()).isEqualTo(genericContainer);
+        assertThat(result.getNativeKafkaProperties()).isEqualTo(properties);
+    }
+
+    @Test
+    @DisplayName("should handle directory creation with proper permissions")
+    void shouldHandleDirectoryCreationWithProperPermissions() {
+        Path testPath = tempDir.resolve("test-kafka-data");
+
+        NativeKafkaConfigurationProperties.FileSystemBind fileSystemBind =
+                new NativeKafkaConfigurationProperties.FileSystemBind(true, testPath.toString());
+
+        when(environment.getPropertySources()).thenReturn(mutablePropertySources);
+        when(properties.getDefaultDockerImage()).thenReturn("apache/kafka-native:4.0.0");
+        when(properties.getFileSystemBind()).thenReturn(fileSystemBind);
+        when(properties.getKafkaPort()).thenReturn(9092);
+
+        try (MockedStatic<com.playtika.testcontainer.common.utils.ContainerUtils> containerUtilsMock =
+                mockStatic(com.playtika.testcontainer.common.utils.ContainerUtils.class)) {
+
+            containerUtilsMock.when(() -> configureCommonsAndStart(any(KafkaContainer.class), eq(properties), any()))
+                    .thenReturn(kafkaContainer);
+
+            when(kafkaContainer.getBootstrapServers()).thenReturn("localhost:9092");
+            when(kafkaContainer.getHost()).thenReturn("localhost");
+            when(kafkaContainer.getMappedPort(9092)).thenReturn(9092);
+
+            configuration.nativeKafka(properties, environment, network);
+
+            assertThat(Files.exists(testPath)).isTrue();
+            assertThat(Files.isDirectory(testPath)).isTrue();
+        }
+    }
+
+    @Test
+    @DisplayName("should handle parent directory creation")
+    void shouldHandleParentDirectoryCreation() throws IOException {
+        Path parentPath = tempDir.resolve("parent");
+        Files.createDirectory(parentPath);
+        Path testPath = parentPath.resolve("test-kafka-data");
+
+        NativeKafkaConfigurationProperties.FileSystemBind fileSystemBind =
+                new NativeKafkaConfigurationProperties.FileSystemBind(true, testPath.toString());
+
+        when(environment.getPropertySources()).thenReturn(mutablePropertySources);
+        when(properties.getDefaultDockerImage()).thenReturn("apache/kafka-native:4.0.0");
+        when(properties.getFileSystemBind()).thenReturn(fileSystemBind);
+        when(properties.getKafkaPort()).thenReturn(9092);
+
+        try (MockedStatic<com.playtika.testcontainer.common.utils.ContainerUtils> containerUtilsMock =
+                mockStatic(com.playtika.testcontainer.common.utils.ContainerUtils.class)) {
+
+            containerUtilsMock.when(() -> configureCommonsAndStart(any(KafkaContainer.class), eq(properties), any()))
+                    .thenReturn(kafkaContainer);
+
+            when(kafkaContainer.getBootstrapServers()).thenReturn("localhost:9092");
+            when(kafkaContainer.getHost()).thenReturn("localhost");
+            when(kafkaContainer.getMappedPort(9092)).thenReturn(9092);
+
+            configuration.nativeKafka(properties, environment, network);
+
+            assertThat(Files.exists(parentPath)).isTrue();
+            assertThat(Files.exists(testPath)).isTrue();
+        }
+    }
+
+    @Test
+    @DisplayName("should verify container host name constant")
+    void shouldVerifyContainerHostNameConstant() {
+        assertThat(NativeKafkaContainerConfiguration.NATIVE_KAFKA_HOST_NAME)
+                .isEqualTo("native-kafka-broker.testcontainer.docker");
+    }
+
+    @Test
+    @DisplayName("should handle existing directory scenario")
+    void shouldHandleExistingDirectoryScenario() throws IOException {
+        Path existingPath = tempDir.resolve("existing-kafka-data");
+        Files.createDirectory(existingPath);
+
+        NativeKafkaConfigurationProperties.FileSystemBind fileSystemBind =
+                new NativeKafkaConfigurationProperties.FileSystemBind(true, existingPath.toString());
+
+        when(environment.getPropertySources()).thenReturn(mutablePropertySources);
+        when(properties.getDefaultDockerImage()).thenReturn("apache/kafka-native:4.0.0");
+        when(properties.getFileSystemBind()).thenReturn(fileSystemBind);
+        when(properties.getKafkaPort()).thenReturn(9092);
+
+        try (MockedStatic<com.playtika.testcontainer.common.utils.ContainerUtils> containerUtilsMock =
+                mockStatic(com.playtika.testcontainer.common.utils.ContainerUtils.class)) {
+
+            containerUtilsMock.when(() -> configureCommonsAndStart(any(KafkaContainer.class), eq(properties), any()))
+                    .thenReturn(kafkaContainer);
+
+            when(kafkaContainer.getBootstrapServers()).thenReturn("localhost:9092");
+            when(kafkaContainer.getHost()).thenReturn("localhost");
+            when(kafkaContainer.getMappedPort(9092)).thenReturn(9092);
+
+            configuration.nativeKafka(properties, environment, network);
+
+            assertThat(Files.exists(existingPath)).isTrue();
+        }
+    }
+}

--- a/embedded-native-kafka/src/test/java/com/playtika/testcontainer/nativekafka/properties/NativeKafkaConfigurationPropertiesTest.java
+++ b/embedded-native-kafka/src/test/java/com/playtika/testcontainer/nativekafka/properties/NativeKafkaConfigurationPropertiesTest.java
@@ -1,0 +1,22 @@
+package com.playtika.testcontainer.nativekafka.properties;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static nl.jqno.equalsverifier.Warning.NONFINAL_FIELDS;
+import static nl.jqno.equalsverifier.Warning.STRICT_INHERITANCE;
+
+@DisplayName("Test that NativeKafkaConfigurationProperties")
+public class NativeKafkaConfigurationPropertiesTest {
+
+    @Test
+    @DisplayName("respects contract for equals & hashCode")
+    public void shouldRespectEqualsAndHashcodeContract() {
+        EqualsVerifier
+                .forClass(NativeKafkaConfigurationProperties.class)
+                .suppress(NONFINAL_FIELDS, STRICT_INHERITANCE)
+                .withRedefinedSuperclass()
+                .verify();
+    }
+}

--- a/embedded-native-kafka/src/test/resources/junit-platform.properties
+++ b/embedded-native-kafka/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation

--- a/embedded-native-kafka/src/test/resources/log4j2.xml
+++ b/embedded-native-kafka/src/test/resources/log4j2.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration shutdownHook="disable">
+    <Appenders>
+        <Console name="console" target="SYSTEM_OUT"  follow="true">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} %-5p - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Logger name="com.playtika.testcontainer" level="info"/>
+        <Logger name="org.springframework" level="error"/>
+        <Root level="error">
+            <AppenderRef ref="console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <module>testcontainers-spring-boot-parent</module>
         <module>testcontainers-common</module>
         <module>embedded-kafka</module>
+        <module>embedded-native-kafka</module>
         <module>embedded-keycloak</module>
         <module>embedded-keydb</module>
         <module>embedded-aerospike</module>

--- a/testcontainers-spring-boot-bom/pom.xml
+++ b/testcontainers-spring-boot-bom/pom.xml
@@ -72,6 +72,11 @@
             </dependency>
             <dependency>
                 <groupId>com.playtika.testcontainers</groupId>
+                <artifactId>embedded-native-kafka</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.playtika.testcontainers</groupId>
                 <artifactId>embedded-keycloak</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
Motivation:

Adding native Kafka speed ups tests, although currently functionality is limited and does not support toxiproxy and SASL authentication mechanisms.

Note:
SASL mechanism is not supported by native image because some security mechanism are not available in SubstrateVM.

Modification:

Added new embedded-native-kafka module 

Result:

Fixes #2070

