### PR TITLE
Vertica Community Edition Docker Image Not Available on Docker Hub

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <module>embedded-clickhouse</module>
         <module>embedded-selenium</module>
         <module>embedded-pulsar</module>
-        <module>embedded-vertica</module>
+<!--        <module>embedded-vertica</module>-->
         <module>embedded-prometheus</module>
         <module>embedded-grafana</module>
         <module>embedded-consul</module>


### PR DESCRIPTION
Motivation:

Vertica Community Edition Docker Image Not Available on Docker Hub

Modification:

Disable vertica module temporary.

Result:

https://github.com/vertica/vertica-containers/issues/64

