### PR TITLE
feat(embedded-localstack): align property names with AWS SDK v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     ignore:
       - dependency-name: "com.amazonaws:*"
         update-types: ["version-update:semver-patch"]
+      - dependency-name: "software.amazon.awssdk:*"
+        update-types: ["version-update:semver-patch"]
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "develop"

--- a/embedded-localstack/README.adoc
+++ b/embedded-localstack/README.adoc
@@ -28,8 +28,9 @@
 ==== Produces
 
 * `embedded.localstack.host`
+* `embedded.localstack.endpointUrl`
 * `embedded.localstack.accessKey`
-* `embedded.localstack.secretKey`
+* `embedded.localstack.secretAccessKey`
 * `embedded.localstack.{service}` (service endpoint for connection)
 * `embedded.localstack.{service}.port` (mapped port for connection)
 * `embedded.localstack.toxiproxy.host`

--- a/embedded-localstack/pom.xml
+++ b/embedded-localstack/pom.xml
@@ -14,8 +14,20 @@
     <artifactId>embedded-localstack</artifactId>
 
     <properties>
-        <aws-java-sdk.version>1.12.701</aws-java-sdk.version>
+        <aws-sdk.version>2.41.0</aws-sdk.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${aws-sdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -31,9 +43,8 @@
             <artifactId>localstack</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-s3</artifactId>
-            <version>${aws-java-sdk.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -43,9 +54,8 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-sqs</artifactId>
-            <version>${aws-java-sdk.version}</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sqs</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/embedded-localstack/src/main/java/com/playtika/testcontainer/localstack/EmbeddedLocalStackBootstrapConfiguration.java
+++ b/embedded-localstack/src/main/java/com/playtika/testcontainer/localstack/EmbeddedLocalStackBootstrapConfiguration.java
@@ -87,8 +87,9 @@ public class EmbeddedLocalStackBootstrapConfiguration {
 
         LinkedHashMap<String, Object> map = new LinkedHashMap<>();
         map.put("embedded.localstack.host", host);
+        map.put("embedded.localstack.endpointUrl", localStack.getEndpoint().toString());
         map.put("embedded.localstack.accessKey", localStack.getAccessKey());
-        map.put("embedded.localstack.secretKey", localStack.getSecretKey());
+        map.put("embedded.localstack.secretAccessKey", localStack.getSecretKey());
         map.put("embedded.localstack.networkAlias", LOCALSTACK_NETWORK_ALIAS);
         map.put("embedded.localstack.internalEdgePort", properties.getEdgePort());
         String prefix = "embedded.localstack.";
@@ -105,8 +106,9 @@ public class EmbeddedLocalStackBootstrapConfiguration {
     }
 
     private static void setSystemProperties(LocalStackContainer localStack) {
+        System.setProperty("aws.endpointUrl", localStack.getEndpoint().toString());
         System.setProperty("aws.accessKeyId", localStack.getAccessKey());
-        System.setProperty("aws.secretKey", localStack.getAccessKey());
+        System.setProperty("aws.secretAccessKey", localStack.getSecretKey());
     }
 
 }

--- a/embedded-localstack/src/test/java/com/playtika/testcontainer/localstack/EmbeddedLocalStackTest.java
+++ b/embedded-localstack/src/test/java/com/playtika/testcontainer/localstack/EmbeddedLocalStackTest.java
@@ -1,29 +1,34 @@
 package com.playtika.testcontainer.localstack;
 
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.regions.Regions;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import com.amazonaws.services.s3.model.Bucket;
-import com.amazonaws.services.s3.model.CreateBucketRequest;
-import com.amazonaws.services.s3.model.ObjectListing;
-import com.amazonaws.services.s3.model.Region;
-import com.amazonaws.services.s3.model.S3Object;
-import com.amazonaws.services.sqs.AmazonSQS;
-import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
-import com.amazonaws.services.sqs.model.CreateQueueResult;
-import com.amazonaws.services.sqs.model.SendMessageRequest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.ConfigurableEnvironment;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.Bucket;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.CreateQueueRequest;
+import software.amazon.awssdk.services.sqs.model.CreateQueueResponse;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
@@ -39,8 +44,8 @@ public class EmbeddedLocalStackTest {
     @Value("${embedded.localstack.accessKey}")
     private String accessKey;
 
-    @Value("${embedded.localstack.secretKey}")
-    private String secretKey;
+    @Value("${embedded.localstack.secretAccessKey}")
+    private String secretAccessKey;
 
     @Value("${embedded.localstack.S3}")
     private String s3Endpoint;
@@ -48,81 +53,127 @@ public class EmbeddedLocalStackTest {
     @Value("${embedded.localstack.SQS}")
     private String sqsEndpoint;
 
-    @Value("${embedded.localstack.SQS.port}")
-    private String sqsPort;
-
     @Autowired
     private ConfigurableEnvironment environment;
 
-    @Autowired
-    private LocalStackProperties properties;
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(ClientCreationStrategy.class)
+    public void shouldStartS3(ClientCreationStrategy strategy) {
+        S3Client s3 = strategy.createS3Client(
+            s3Endpoint,
+            Region.US_WEST_2,
+            accessKey,
+            secretAccessKey);
 
-    @Test
-    public void shouldStartS3() {
-        AmazonS3 s3 = AmazonS3ClientBuilder
-                .standard()
-                .withEndpointConfiguration(getEndpointConfiguration(s3Endpoint))
-                .withCredentials(getAwsCredentialsProvider())
-                .build();
+        String bucketName = "foo-" + strategy.name().toLowerCase().replace("_", "-");
+        s3.createBucket(CreateBucketRequest.builder().bucket(bucketName).build());
 
-        String bucketName = "foo";
-        s3.createBucket(new CreateBucketRequest(bucketName, Region.US_West_2));
-        s3.putObject(bucketName, "bar", "baz");
+        String objectKey = "bar";
+        String objectContent = "baz";
+        s3.putObject(PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(), RequestBody.fromString(objectContent));
 
-        List<Bucket> buckets = s3.listBuckets();
-        Optional<Bucket> maybeBucket = buckets.stream().filter(b -> b.getName().equals(bucketName)).findFirst();
+        List<Bucket> buckets = s3.listBuckets().buckets();
+        Optional<Bucket> maybeBucket = buckets.stream().filter(b -> b.name().equals(bucketName)).findFirst();
         assertThat(maybeBucket).isPresent();
 
         Bucket bucket = maybeBucket.get();
-        assertThat(bucketName).isEqualTo(bucket.getName());
+        assertThat(bucketName).isEqualTo(bucket.name());
 
-        ObjectListing objectListing = s3.listObjects(bucketName);
-        assertThat(objectListing.getObjectSummaries()).hasSize(1);
+        ListObjectsResponse listObjectsResponse = s3.listObjects(ListObjectsRequest.builder().bucket(bucketName).build());
+        assertThat(listObjectsResponse.contents()).hasSize(1);
 
-        S3Object object = s3.getObject(bucketName, "bar");
-        assertThat(object.getObjectContent()).asString(StandardCharsets.UTF_8).isEqualTo("baz");
+        ResponseBytes<GetObjectResponse> object = s3.getObjectAsBytes(GetObjectRequest.builder().bucket(bucketName).key(objectKey).build());
+        assertThat(object.asByteArray()).asString(StandardCharsets.UTF_8).isEqualTo(objectContent);
     }
 
-    @Test
-    public void shouldStartSQS() {
-        AmazonSQS sqs = AmazonSQSClientBuilder.standard()
-                .withEndpointConfiguration(getEndpointConfiguration(sqsEndpoint))
-                .withCredentials(getAwsCredentialsProvider())
-                .build();
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(ClientCreationStrategy.class)
+    public void shouldStartSQS(ClientCreationStrategy strategy) {
+        SqsClient sqs = strategy.createSqsClient(
+            sqsEndpoint,
+            Region.US_WEST_2,
+            accessKey,
+            secretAccessKey);
 
-        CreateQueueResult queueResult = sqs.createQueue("baz");
-        String fooQueueUrl = queueResult.getQueueUrl();
+        String queueName = "baz-" + strategy.name().toLowerCase().replace("_", "-");
+        CreateQueueResponse createQueueResponse = sqs.createQueue(CreateQueueRequest.builder().queueName(queueName).build());
+        String queueUrl = createQueueResponse.queueUrl();
 
-        SendMessageRequest sendMessageRequest = new SendMessageRequest();
-        sendMessageRequest.setQueueUrl(fooQueueUrl);
-        sendMessageRequest.setMessageBody("test");
-        sqs.sendMessage(sendMessageRequest);
+        String messageBody = "test";
+        sqs.sendMessage(SendMessageRequest.builder().queueUrl(queueUrl).messageBody(messageBody).build());
 
-        long messageCount = sqs.receiveMessage(fooQueueUrl).getMessages().stream()
-                .filter(message -> message.getBody().equals("test"))
-                .count();
+        long messageCount = sqs.receiveMessage(ReceiveMessageRequest.builder().queueUrl(queueUrl).build()).messages().stream()
+            .filter(message -> message.body().equals(messageBody))
+            .count();
         assertThat(messageCount).isEqualTo(1);
     }
 
     @Test
     public void shouldProduceLocalstackProperties() {
         assertThat(environment.getProperty("embedded.localstack.host")).isNotEmpty();
+        assertThat(environment.getProperty("embedded.localstack.endpointUrl")).isNotEmpty();
         assertThat(environment.getProperty("embedded.localstack.accessKey")).isNotEmpty();
-        assertThat(environment.getProperty("embedded.localstack.secretKey")).isNotEmpty();
+        assertThat(environment.getProperty("embedded.localstack.secretAccessKey")).isNotEmpty();
         assertThat(environment.getProperty("embedded.localstack.S3")).isNotEmpty();
         assertThat(environment.getProperty("embedded.localstack.S3.port")).isNotEmpty();
-    }
-
-    private AwsClientBuilder.EndpointConfiguration getEndpointConfiguration(String endpoint) {
-        return new AwsClientBuilder.EndpointConfiguration(endpoint, Regions.DEFAULT_REGION.getName());
-    }
-
-    private AWSCredentialsProvider getAwsCredentialsProvider() {
-        return new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey));
+        assertThat(environment.getProperty("embedded.localstack.SQS")).isNotEmpty();
+        assertThat(environment.getProperty("embedded.localstack.SQS.port")).isNotEmpty();
     }
 
     @Configuration
     @EnableAutoConfiguration
     static class TestConfiguration {
+    }
+
+    public enum ClientCreationStrategy {
+        EXPLICIT {
+            @Override
+            public S3Client createS3Client(String endpoint, Region region,
+                                           String accessKey, String secretAccessKey) {
+                return S3Client.builder()
+                    .region(region)
+                    .endpointOverride(URI.create(endpoint))
+                    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretAccessKey)))
+                    .build();
+            }
+
+            @Override
+            public SqsClient createSqsClient(String endpoint, Region region,
+                                             String accessKey, String secretAccessKey) {
+                return SqsClient.builder()
+                    .region(region)
+                    .endpointOverride(URI.create(endpoint))
+                    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretAccessKey)))
+                    .build();
+            }
+        },
+
+        AUTO_DISCOVERY {
+            @Override
+            public S3Client createS3Client(String endpoint, Region region,
+                                           String accessKey, String secretAccessKey) {
+                // System properties are already set by EmbeddedLocalStackBootstrapConfiguration
+                // Client relies on auto-discovery from those system properties
+                return S3Client.builder()
+                    .region(region)
+                    .build();
+            }
+
+            @Override
+            public SqsClient createSqsClient(String endpoint, Region region,
+                                             String accessKey, String secretAccessKey) {
+                // System properties are already set by EmbeddedLocalStackBootstrapConfiguration
+                // Client relies on auto-discovery from those system properties
+                return SqsClient.builder()
+                    .region(region)
+                    .build();
+            }
+        };
+
+        public abstract S3Client createS3Client(String endpoint, Region region,
+                                                String accessKey, String secretAccessKey);
+
+        public abstract SqsClient createSqsClient(String endpoint, Region region,
+                                                  String accessKey, String secretAccessKey);
     }
 }


### PR DESCRIPTION
## Motivation
This change improves consistency with AWS SDK v2 conventions, which is important as AWS SDK v1 reached end-of-life on December 31, 2025. AWS SDK v2 provides more convinent way to configure clients.

## Modifications
- Rename secretKey to secretAccessKey to match AWS SDK v2 naming conventions
- Add embedded.localstack.endpointUrl Spring property to export the global endpoint URL
- Add parameterized tests to verify both explicit configuration and auto-discovery from system properties
- Update tests to verify both S3 and SQS properties are set correctly
- Update documentation to reflect new property names

## Breaking Changes
**Property Renamed:**
- Old: `${embedded.localstack.secretKey}`
- New: `${embedded.localstack.secretAccessKey}`

**Migration Required:**
Applications must update their configuration to use the new property name.
