### PR TITLE
partially revert to spring-core for properties emission

### DIFF
--- a/embedded-aerospike/src/main/java/com/playtika/testcontainer/aerospike/EmbeddedAerospikeBootstrapConfiguration.java
+++ b/embedded-aerospike/src/main/java/com/playtika/testcontainer/aerospike/EmbeddedAerospikeBootstrapConfiguration.java
@@ -9,7 +9,6 @@ import com.playtika.testcontainer.toxiproxy.ToxiproxyHelper;
 import com.playtika.testcontainer.toxiproxy.condition.ConditionalOnToxiProxyEnabled;
 import eu.rekawek.toxiproxy.ToxiproxyClient;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -18,7 +17,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
@@ -26,6 +26,7 @@ import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.aerospike.AerospikeProperties.BEAN_NAME_AEROSPIKE;
@@ -53,35 +54,21 @@ public class EmbeddedAerospikeBootstrapConfiguration {
     ToxiproxyClientProxy aerospikeContainerProxy(ToxiproxyClient toxiproxyClient,
                                                   ToxiproxyContainer toxiproxyContainer,
                                                   GenericContainer<?> aerospike,
-                                                  AerospikeProperties properties) {
-        return ToxiproxyHelper.createProxy(
+                                                  AerospikeProperties properties,
+                                                  ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 aerospike,
                 properties.port,
                 "aerospike");
-    }
-
-    @Bean
-    public DynamicPropertyRegistrar aerospikeDynamicPropertyRegistrar(GenericContainer<?> aerospike, AerospikeProperties properties) {
-        return registry -> {
-            registry.add("embedded.aerospike.host", aerospike::getHost);
-            registry.add("embedded.aerospike.port", () -> aerospike.getMappedPort(properties.port));
-            registry.add("embedded.aerospike.namespace", () -> properties.namespace);
-            registry.add("embedded.aerospike.networkAlias", () -> AEROSPIKE_NETWORK_ALIAS);
-            registry.add("embedded.aerospike.internalPort", () -> properties.port);
-        };
-    }
-
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "aerospike")
-    public DynamicPropertyRegistrar aerospikeToxiProxyDynamicPropertyRegistrar(
-        @Qualifier("aerospikeContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.aerospike");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.aerospike", "embeddedAerospikeToxiProxyInfo", environment);
+        return proxy;
     }
 
     @Bean(name = BEAN_NAME_AEROSPIKE, destroyMethod = "stop")
-    public GenericContainer<?> aerospike(AerospikeWaitStrategy aerospikeWaitStrategy,
+    public GenericContainer<?> aerospike(ConfigurableEnvironment environment,
+                                      AerospikeWaitStrategy aerospikeWaitStrategy,
                                       AerospikeProperties properties,
                                       Optional<Network> network) {
         WaitStrategy waitStrategy = new WaitAllStrategy()
@@ -108,8 +95,24 @@ public class EmbeddedAerospikeBootstrapConfiguration {
                 .withEnv("FEATURE_KEY_FILE", "env-b64:FEATURES");
         }
         aerospike = configureCommonsAndStart(aerospike, properties, log);
+        registerAerospikeEnvironment(aerospike, environment, properties);
+        return aerospike;
+    }
+
+    private void registerAerospikeEnvironment(GenericContainer<?> aerospike,
+                                              ConfigurableEnvironment environment,
+                                              AerospikeProperties properties) {
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.aerospike.host", aerospike.getHost());
+        map.put("embedded.aerospike.port", aerospike.getMappedPort(properties.port));
+        map.put("embedded.aerospike.namespace", properties.namespace);
+        map.put("embedded.aerospike.networkAlias", AEROSPIKE_NETWORK_ALIAS);
+        map.put("embedded.aerospike.internalPort", properties.port);
+
         log.info("Started aerospike server. Connection details host={}, port={}, namespace={}, networkAlias={}, internalPort={}",
                 aerospike.getHost(), aerospike.getMappedPort(properties.port), properties.namespace, AEROSPIKE_NETWORK_ALIAS, properties.port);
-        return aerospike;
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedAerospikeInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 }

--- a/embedded-artifactory/src/main/java/com/playtika/testcontainer/artifactory/EmbeddedArtifactoryBootstrapConfiguration.java
+++ b/embedded-artifactory/src/main/java/com/playtika/testcontainer/artifactory/EmbeddedArtifactoryBootstrapConfiguration.java
@@ -15,13 +15,15 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.artifactory.ArtifactoryProperties.ARTIFACTORY_BEAN_NAME;
@@ -51,23 +53,21 @@ public class EmbeddedArtifactoryBootstrapConfiguration {
     ToxiproxyClientProxy artifactoryContainerProxy(ToxiproxyClient toxiproxyClient,
                                                     ToxiproxyContainer toxiproxyContainer,
                                                     @Qualifier(ARTIFACTORY_BEAN_NAME) GenericContainer<?> artifactory,
-                                                    ArtifactoryProperties properties) {
-        return ToxiproxyHelper.createProxy(
+                                                    ArtifactoryProperties properties,
+                                                    ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 artifactory,
                 properties.getRestApiPort(),
                 "artifactory");
-    }
-
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "artifactory")
-    public DynamicPropertyRegistrar artifactoryToxiProxyDynamicPropertyRegistrar(@Qualifier("artifactoryContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.artifactory");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.artifactory", "embeddedArtifactoryToxiProxyInfo", environment);
+        return proxy;
     }
 
     @Bean(name = ARTIFACTORY_BEAN_NAME, destroyMethod = "stop")
-    public GenericContainer<?> artifactory(ArtifactoryProperties properties,
+    public GenericContainer<?> artifactory(ConfigurableEnvironment environment,
+                                           ArtifactoryProperties properties,
                                            WaitStrategy artifactoryWaitStrategy,
                                            Optional<Network> network) {
         GenericContainer<?> container =
@@ -78,23 +78,29 @@ public class EmbeddedArtifactoryBootstrapConfiguration {
                         .waitingFor(artifactoryWaitStrategy);
         network.ifPresent(container::withNetwork);
         configureCommonsAndStart(container, properties, log);
-        Integer mappedPort = container.getMappedPort(properties.generalPort);
-        String host = container.getHost();
-        log.info("Started Artifactory server. Connection details: host={}, port={}, username={}, password={}, staticNetworkAlias={}, internalRestApiPort={}, internalGeneralPort={}",
-                host, mappedPort, properties.getUsername(), properties.getPassword(), ARTIFACTORY_NETWORK_ALIAS, properties.getRestApiPort(), properties.getGeneralPort());
+        registerArtifactoryEnvironment(container, environment, properties);
         return container;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar artifactoryDynamicPropertyRegistrar(@Qualifier(ARTIFACTORY_BEAN_NAME) GenericContainer<?> artifactory, ArtifactoryProperties properties) {
-        return registry -> {
-            registry.add("embedded.artifactory.host", artifactory::getHost);
-            registry.add("embedded.artifactory.port", () -> artifactory.getMappedPort(properties.generalPort));
-            registry.add("embedded.artifactory.username", properties::getUsername);
-            registry.add("embedded.artifactory.password", properties::getPassword);
-            registry.add("embedded.artifactory.staticNetworkAlias", () -> ARTIFACTORY_NETWORK_ALIAS);
-            registry.add("embedded.artifactory.internalRestApiPort", properties::getRestApiPort);
-            registry.add("embedded.artifactory.internalGeneralPort", properties::getGeneralPort);
-        };
+    private void registerArtifactoryEnvironment(GenericContainer<?> artifactory,
+                                                ConfigurableEnvironment environment,
+                                                ArtifactoryProperties properties) {
+        Integer mappedPort = artifactory.getMappedPort(properties.generalPort);
+        String host = artifactory.getHost();
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.artifactory.host", host);
+        map.put("embedded.artifactory.port", mappedPort);
+        map.put("embedded.artifactory.username", properties.getUsername());
+        map.put("embedded.artifactory.password", properties.getPassword());
+        map.put("embedded.artifactory.staticNetworkAlias", ARTIFACTORY_NETWORK_ALIAS);
+        map.put("embedded.artifactory.internalRestApiPort", properties.getRestApiPort());
+        map.put("embedded.artifactory.internalGeneralPort", properties.getGeneralPort());
+
+        log.info("Started Artifactory server. Connection details: host={}, port={}, username={}, password={}, staticNetworkAlias={}, internalRestApiPort={}, internalGeneralPort={}",
+                host, mappedPort, properties.getUsername(), properties.getPassword(), ARTIFACTORY_NETWORK_ALIAS, properties.getRestApiPort(), properties.getGeneralPort());
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedArtifactoryInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 }

--- a/embedded-azurite/src/main/java/com/playtika/testcontainer/azurite/EmbeddedAzuriteBootstrapConfiguration.java
+++ b/embedded-azurite/src/main/java/com/playtika/testcontainer/azurite/EmbeddedAzuriteBootstrapConfiguration.java
@@ -17,11 +17,13 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -48,28 +50,28 @@ public class EmbeddedAzuriteBootstrapConfiguration {
     ToxiproxyClientProxy azuriteBlobContainerProxy(ToxiproxyClient toxiproxyClient,
                                                     ToxiproxyContainer toxiproxyContainer,
                                                     @Qualifier(AZURITE_BEAN_NAME) GenericContainer<?> azurite,
-                                                    AzuriteProperties properties) {
-        return ToxiproxyHelper.createProxy(
+                                                    AzuriteProperties properties,
+                                                    ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 azurite,
                 properties.getBlobStoragePort(),
                 "azurite");
-    }
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "azurite")
-    public DynamicPropertyRegistrar azuriteBlobToxiProxyDynamicPropertyRegistrar(ToxiproxyClientProxy azuriteBlobContainerProxy) {
-        return registry -> {
-            registry.add("embedded.azurite.toxiproxy.host", azuriteBlobContainerProxy::getContainerIpAddress);
-            registry.add("embedded.azurite.toxiproxy.blobStoragePort", azuriteBlobContainerProxy::getProxyPort);
-            registry.add("embedded.azurite.toxiproxy.proxyName", azuriteBlobContainerProxy::getName);
-            log.info("Started Azurite ToxiProxy connection details {}", Map.of(
-                "embedded.azurite.toxiproxy.host", azuriteBlobContainerProxy.getContainerIpAddress(),
-                "embedded.azurite.toxiproxy.blobStoragePort", azuriteBlobContainerProxy.getProxyPort(),
-                "embedded.azurite.toxiproxy.proxyName", azuriteBlobContainerProxy.getName()
-            ));
-        };
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.azurite.toxiproxy.host", proxy.getContainerIpAddress());
+        map.put("embedded.azurite.toxiproxy.blobStoragePort", proxy.getProxyPort());
+        map.put("embedded.azurite.toxiproxy.proxyName", proxy.getName());
+        log.info("Started Azurite ToxiProxy connection details {}", Map.of(
+            "embedded.azurite.toxiproxy.host", proxy.getContainerIpAddress(),
+            "embedded.azurite.toxiproxy.blobStoragePort", proxy.getProxyPort(),
+            "embedded.azurite.toxiproxy.proxyName", proxy.getName()
+        ));
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedAzuriteBlobToxiProxyInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
+        return proxy;
     }
 
     @Bean
@@ -77,28 +79,28 @@ public class EmbeddedAzuriteBootstrapConfiguration {
     ToxiproxyClientProxy azuriteQueueContainerProxy(ToxiproxyClient toxiproxyClient,
                                                      ToxiproxyContainer toxiproxyContainer,
                                                      @Qualifier(AZURITE_BEAN_NAME) GenericContainer<?> azurite,
-                                                     AzuriteProperties properties) {
-        return ToxiproxyHelper.createProxy(
+                                                     AzuriteProperties properties,
+                                                     ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
             toxiproxyClient,
             toxiproxyContainer,
             azurite,
             properties.getQueueStoragePort(),
             "azurite");
-    }
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "azurite")
-    public DynamicPropertyRegistrar azuriteQueueToxiProxyDynamicPropertyRegistrar(ToxiproxyClientProxy azuriteQueueContainerProxy) {
-        return registry -> {
-            registry.add("embedded.azurite.toxiproxy.host", azuriteQueueContainerProxy::getContainerIpAddress);
-            registry.add("embedded.azurite.toxiproxy.queueStoragePort", azuriteQueueContainerProxy::getProxyPort);
-            registry.add("embedded.azurite.toxiproxy.proxyName", azuriteQueueContainerProxy::getName);
-            log.info("Started Azurite ToxiProxy connection details {}", Map.of(
-                "embedded.azurite.toxiproxy.host", azuriteQueueContainerProxy.getContainerIpAddress(),
-                "embedded.azurite.toxiproxy.queueStoragePort", azuriteQueueContainerProxy.getProxyPort(),
-                "embedded.azurite.toxiproxy.proxyName", azuriteQueueContainerProxy.getName()
-            ));
-        };
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.azurite.toxiproxy.host", proxy.getContainerIpAddress());
+        map.put("embedded.azurite.toxiproxy.queueStoragePort", proxy.getProxyPort());
+        map.put("embedded.azurite.toxiproxy.proxyName", proxy.getName());
+        log.info("Started Azurite ToxiProxy connection details {}", Map.of(
+            "embedded.azurite.toxiproxy.host", proxy.getContainerIpAddress(),
+            "embedded.azurite.toxiproxy.queueStoragePort", proxy.getProxyPort(),
+            "embedded.azurite.toxiproxy.proxyName", proxy.getName()
+        ));
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedAzuriteQueueToxiProxyInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
+        return proxy;
     }
 
     @Bean
@@ -106,33 +108,33 @@ public class EmbeddedAzuriteBootstrapConfiguration {
     ToxiproxyClientProxy azuriteTableContainerProxy(ToxiproxyClient toxiproxyClient,
                                                      ToxiproxyContainer toxiproxyContainer,
                                                      @Qualifier(AZURITE_BEAN_NAME) GenericContainer<?> azurite,
-                                                     AzuriteProperties properties) {
-
-        return ToxiproxyHelper.createProxy(
+                                                     AzuriteProperties properties,
+                                                     ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
             toxiproxyClient,
             toxiproxyContainer,
             azurite,
             properties.getTableStoragePort(),
             "azurite");
-    }
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "azurite")
-    public DynamicPropertyRegistrar azuriteTableToxiProxyDynamicPropertyRegistrar(ToxiproxyClientProxy azuriteTableContainerProxy) {
-        return registry -> {
-            registry.add("embedded.azurite.toxiproxy.host", azuriteTableContainerProxy::getContainerIpAddress);
-            registry.add("embedded.azurite.toxiproxy.tableStoragePort", azuriteTableContainerProxy::getProxyPort);
-            registry.add("embedded.azurite.toxiproxy.proxyName", azuriteTableContainerProxy::getName);
-            log.info("Started Azurite ToxiProxy connection details {}", Map.of(
-                "embedded.azurite.toxiproxy.host", azuriteTableContainerProxy.getContainerIpAddress(),
-                "embedded.azurite.toxiproxy.tableStoragePort", azuriteTableContainerProxy.getProxyPort(),
-                "embedded.azurite.toxiproxy.proxyName", azuriteTableContainerProxy.getName()
-            ));
-        };
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.azurite.toxiproxy.host", proxy.getContainerIpAddress());
+        map.put("embedded.azurite.toxiproxy.tableStoragePort", proxy.getProxyPort());
+        map.put("embedded.azurite.toxiproxy.proxyName", proxy.getName());
+        log.info("Started Azurite ToxiProxy connection details {}", Map.of(
+            "embedded.azurite.toxiproxy.host", proxy.getContainerIpAddress(),
+            "embedded.azurite.toxiproxy.tableStoragePort", proxy.getProxyPort(),
+            "embedded.azurite.toxiproxy.proxyName", proxy.getName()
+        ));
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedAzuriteTableToxiProxyInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
+        return proxy;
     }
 
     @Bean(name = AZURITE_BEAN_NAME, destroyMethod = "stop")
-    public GenericContainer<?> azurite(AzuriteProperties properties,
+    public GenericContainer<?> azurite(ConfigurableEnvironment environment,
+                                       AzuriteProperties properties,
                                        Optional<Network> network) {
         GenericContainer<?> azuriteContainer = new GenericContainer<>(ContainerUtils.getDockerImageName(properties))
                 .withExposedPorts(properties.getBlobStoragePort(), properties.getQueueStoragePort(), properties.getTableStoragePort())
@@ -150,37 +152,39 @@ public class EmbeddedAzuriteBootstrapConfiguration {
         network.ifPresent(azuriteContainer::withNetwork);
 
         configureCommonsAndStart(azuriteContainer, properties, log);
+        registerAzuriteEnvironment(azuriteContainer, environment, properties);
         return azuriteContainer;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar azuriteDynamicPropertyRegistrar(
-            @Qualifier(AZURITE_BEAN_NAME) GenericContainer<?> azurite,
-            AzuriteProperties properties) {
-        return registry -> {
-            Integer mappedBlobStoragePort = azurite.getMappedPort(properties.getBlobStoragePort());
-            Integer mappedQueueStoragePort = azurite.getMappedPort(properties.getQueueStoragePort());
-            Integer mappedTableStoragePort = azurite.getMappedPort(properties.getTableStoragePort());
-            String host = azurite.getHost();
+    private void registerAzuriteEnvironment(GenericContainer<?> azurite,
+                                            ConfigurableEnvironment environment,
+                                            AzuriteProperties properties) {
+        Integer mappedBlobStoragePort = azurite.getMappedPort(properties.getBlobStoragePort());
+        Integer mappedQueueStoragePort = azurite.getMappedPort(properties.getQueueStoragePort());
+        Integer mappedTableStoragePort = azurite.getMappedPort(properties.getTableStoragePort());
+        String host = azurite.getHost();
 
-            registry.add("embedded.azurite.host", () -> host);
-            registry.add("embedded.azurite.blobStoragePort", () -> mappedBlobStoragePort);
-            registry.add("embedded.azurite.queueStoragePort", () -> mappedQueueStoragePort);
-            registry.add("embedded.azurite.tableStoragePort", () -> mappedTableStoragePort);
-            registry.add("embedded.azurite.account-name", () -> AzuriteProperties.ACCOUNT_NAME);
-            registry.add("embedded.azurite.account-key", () -> AzuriteProperties.ACCOUNT_KEY);
-            registry.add("embedded.azurite.blob-endpoint", () -> "http://" + host + ":" + mappedBlobStoragePort + "/" + AzuriteProperties.ACCOUNT_NAME);
-            registry.add("embedded.azurite.queue-endpoint", () -> "http://" + host + ":" + mappedQueueStoragePort + "/" + AzuriteProperties.ACCOUNT_NAME);
-            registry.add("embedded.azurite.table-endpoint", () -> "http://" + host + ":" + mappedTableStoragePort + "/" + AzuriteProperties.ACCOUNT_NAME);
-            registry.add("embedded.azurite.networkAlias", () -> AZURITE_BLOB_NETWORK_ALIAS);
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.azurite.host", host);
+        map.put("embedded.azurite.blobStoragePort", mappedBlobStoragePort);
+        map.put("embedded.azurite.queueStoragePort", mappedQueueStoragePort);
+        map.put("embedded.azurite.tableStoragePort", mappedTableStoragePort);
+        map.put("embedded.azurite.account-name", AzuriteProperties.ACCOUNT_NAME);
+        map.put("embedded.azurite.account-key", AzuriteProperties.ACCOUNT_KEY);
+        map.put("embedded.azurite.blob-endpoint", "http://" + host + ":" + mappedBlobStoragePort + "/" + AzuriteProperties.ACCOUNT_NAME);
+        map.put("embedded.azurite.queue-endpoint", "http://" + host + ":" + mappedQueueStoragePort + "/" + AzuriteProperties.ACCOUNT_NAME);
+        map.put("embedded.azurite.table-endpoint", "http://" + host + ":" + mappedTableStoragePort + "/" + AzuriteProperties.ACCOUNT_NAME);
+        map.put("embedded.azurite.networkAlias", AZURITE_BLOB_NETWORK_ALIAS);
 
-            log.info("Started Azurite. Connection details: host={}, blobStoragePort={}, queueStoragePort={}, tableStoragePort={}, " +
-                            "blob-endpoint=http://{}:{}/{}, queue-endpoint=http://{}:{}/{}, table-endpoint=http://{}:{}/{}",
-                    host, mappedBlobStoragePort, mappedQueueStoragePort, mappedTableStoragePort,
-                    host, mappedBlobStoragePort, AzuriteProperties.ACCOUNT_NAME,
-                    host, mappedQueueStoragePort, AzuriteProperties.ACCOUNT_NAME,
-                    host, mappedTableStoragePort, AzuriteProperties.ACCOUNT_NAME);
-        };
+        log.info("Started Azurite. Connection details: host={}, blobStoragePort={}, queueStoragePort={}, tableStoragePort={}, " +
+                        "blob-endpoint=http://{}:{}/{}, queue-endpoint=http://{}:{}/{}, table-endpoint=http://{}:{}/{}",
+                host, mappedBlobStoragePort, mappedQueueStoragePort, mappedTableStoragePort,
+                host, mappedBlobStoragePort, AzuriteProperties.ACCOUNT_NAME,
+                host, mappedQueueStoragePort, AzuriteProperties.ACCOUNT_NAME,
+                host, mappedTableStoragePort, AzuriteProperties.ACCOUNT_NAME);
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedAzuriteInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 
 }

--- a/embedded-cassandra/src/main/java/com/playtika/testcontainer/cassandra/EmbeddedCassandraBootstrapConfiguration.java
+++ b/embedded-cassandra/src/main/java/com/playtika/testcontainer/cassandra/EmbeddedCassandraBootstrapConfiguration.java
@@ -14,8 +14,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.io.ResourceLoader;
-import org.springframework.test.context.DynamicPropertyRegistrar;
 import org.testcontainers.containers.CassandraContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
@@ -25,6 +26,7 @@ import org.testcontainers.ext.ScriptUtils;
 
 import javax.script.ScriptException;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.cassandra.CassandraProperties.BEAN_NAME_EMBEDDED_CASSANDRA;
@@ -52,24 +54,23 @@ public class EmbeddedCassandraBootstrapConfiguration {
     ToxiproxyClientProxy cassandraContainerProxy(ToxiproxyClient toxiproxyClient,
                                                   ToxiproxyContainer toxiproxyContainer,
                                                   @Qualifier(BEAN_NAME_EMBEDDED_CASSANDRA) CassandraContainer cassandra,
-                                                  CassandraProperties properties) {
-        return ToxiproxyHelper.createProxy(
+                                                  CassandraProperties properties,
+                                                  ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 cassandra,
                 properties.getPort(),
                 "cassandra");
-    }
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "cassandra")
-    public DynamicPropertyRegistrar cassandraToxiProxyDynamicPropertyRegistrar(
-        @Qualifier("cassandraContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.cassandra");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.cassandra", "embeddedCassandraToxiProxyInfo", environment);
+
+        return proxy;
     }
 
     @Bean(name = BEAN_NAME_EMBEDDED_CASSANDRA, destroyMethod = "stop")
     public CassandraContainer cassandra(CassandraProperties properties,
+                                        ConfigurableEnvironment environment,
                                         Optional<Network> network) throws Exception {
         CassandraContainer cassandra = new CassandraContainer<>(ContainerUtils.getDockerImageName(properties))
             .withExposedPorts(properties.getPort())
@@ -77,24 +78,27 @@ public class EmbeddedCassandraBootstrapConfiguration {
         network.ifPresent(cassandra::withNetwork);
         cassandra = (CassandraContainer) configureCommonsAndStart(cassandra, properties, log);
         initKeyspace(properties, cassandra);
-        String host = cassandra.getHost();
-        Integer mappedPort = cassandra.getMappedPort(properties.getPort());
-        log.info("Started Cassandra. Connection details: host={}, port={}, datacenter={}, keyspace-name={}, networkAlias={}, internalPort={}",
-            host, mappedPort, DEFAULT_DATACENTER, properties.keyspaceName, CASSANDRA_NETWORK_ALIAS, properties.getPort());
+        registerCassandraEnvironment(cassandra, environment, properties);
         return cassandra;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar cassandraDynamicPropertyRegistrar(
-        @Qualifier(BEAN_NAME_EMBEDDED_CASSANDRA) CassandraContainer cassandra, CassandraProperties properties) {
-        return registry -> {
-            registry.add("embedded.cassandra.port", () -> cassandra.getMappedPort(properties.getPort()));
-            registry.add("embedded.cassandra.host", cassandra::getHost);
-            registry.add("embedded.cassandra.datacenter", () -> DEFAULT_DATACENTER);
-            registry.add("embedded.cassandra.keyspace-name", () -> properties.keyspaceName);
-            registry.add("embedded.cassandra.networkAlias", () -> CASSANDRA_NETWORK_ALIAS);
-            registry.add("embedded.cassandra.internalPort", properties::getPort);
-        };
+    private void registerCassandraEnvironment(CassandraContainer cassandra, ConfigurableEnvironment environment, CassandraProperties properties) {
+        String host = cassandra.getHost();
+        Integer mappedPort = cassandra.getMappedPort(properties.getPort());
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.cassandra.port", mappedPort);
+        map.put("embedded.cassandra.host", host);
+        map.put("embedded.cassandra.datacenter", DEFAULT_DATACENTER);
+        map.put("embedded.cassandra.keyspace-name", properties.keyspaceName);
+        map.put("embedded.cassandra.networkAlias", CASSANDRA_NETWORK_ALIAS);
+        map.put("embedded.cassandra.internalPort", properties.getPort());
+
+        log.info("Started Cassandra. Connection details: host={}, port={}, datacenter={}, keyspace-name={}, networkAlias={}, internalPort={}",
+            host, mappedPort, DEFAULT_DATACENTER, properties.keyspaceName, CASSANDRA_NETWORK_ALIAS, properties.getPort());
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedCassandraInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 
     private void initKeyspace(CassandraProperties properties, CassandraContainer<?> cassandra) throws ScriptException {

--- a/embedded-clickhouse/src/main/java/com/playtika/testcontainer/clickhouse/EmbeddedClickHouseBootstrapConfiguration.java
+++ b/embedded-clickhouse/src/main/java/com/playtika/testcontainer/clickhouse/EmbeddedClickHouseBootstrapConfiguration.java
@@ -14,12 +14,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.springframework.util.StringUtils;
 import org.testcontainers.containers.ClickHouseContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.clickhouse.ClickHouseProperties.BEAN_NAME_EMBEDDED_CLICK_HOUSE;
@@ -40,24 +42,24 @@ public class EmbeddedClickHouseBootstrapConfiguration {
     ToxiproxyClientProxy clickhouseContainerProxy(ToxiproxyClient toxiproxyClient,
                                                    ToxiproxyContainer toxiproxyContainer,
                                                    @Qualifier(BEAN_NAME_EMBEDDED_CLICK_HOUSE) ClickHouseContainer clickHouseContainer,
-                                                   ClickHouseProperties properties) {
+                                                   ClickHouseProperties properties,
+                                                   ConfigurableEnvironment environment) {
 
-        return ToxiproxyHelper.createProxy(
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 clickHouseContainer,
                 properties.getPort(),
                 "clickhouse");
-    }
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "clickhouse")
-    public DynamicPropertyRegistrar clickhouseToxiProxyDynamicPropertyRegistrar(@Qualifier("clickhouseContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.clickhouse");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.clickhouse", "embeddedClickhouseToxiProxyInfo", environment);
+
+        return proxy;
     }
 
     @Bean(name = BEAN_NAME_EMBEDDED_CLICK_HOUSE, destroyMethod = "stop")
     public ClickHouseContainer clickHouseContainer(ClickHouseProperties properties,
+                                                   ConfigurableEnvironment environment,
                                                    Optional<Network> network) {
         ClickHouseContainer clickHouseContainer = new ClickHouseContainer(ContainerUtils.getDockerImageName(properties))
                 .withInitScript(properties.getInitScriptPath())
@@ -68,24 +70,28 @@ public class EmbeddedClickHouseBootstrapConfiguration {
         clickHouseContainer.addEnv("CLICKHOUSE_USER", username);
         clickHouseContainer.addEnv("CLICKHOUSE_PASSWORD", password == null ? "" : password);
         clickHouseContainer = (ClickHouseContainer) configureCommonsAndStart(clickHouseContainer, properties, log);
-        Integer mappedPort = clickHouseContainer.getMappedPort(properties.port);
-        String host = clickHouseContainer.getHost();
-        log.info("Started ClickHouse server. Connection details: schema=default, host={}, port={}, user={}, password={}, networkAlias={}, internalPort={}",
-                host, mappedPort, username, password, CLICKHOUSE_NETWORK_ALIAS, properties.getPort());
+        registerClickHouseEnvironment(clickHouseContainer, environment, properties, username, password);
         return clickHouseContainer;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar clickhouseDynamicPropertyRegistrar(@Qualifier(BEAN_NAME_EMBEDDED_CLICK_HOUSE) ClickHouseContainer clickHouseContainer, ClickHouseProperties properties) {
-        return registry -> {
-            registry.add("embedded.clickhouse.schema", () -> "default");
-            registry.add("embedded.clickhouse.host", clickHouseContainer::getHost);
-            registry.add("embedded.clickhouse.port", () -> clickHouseContainer.getMappedPort(properties.port));
-            registry.add("embedded.clickhouse.user", () -> !StringUtils.hasLength(properties.getUser()) ? clickHouseContainer.getUsername() : properties.getUser());
-            registry.add("embedded.clickhouse.password", () -> !StringUtils.hasLength(properties.getPassword()) ? clickHouseContainer.getPassword() : properties.getPassword());
-            registry.add("embedded.clickhouse.networkAlias", () -> CLICKHOUSE_NETWORK_ALIAS);
-            registry.add("embedded.clickhouse.internalPort", properties::getPort);
-        };
+    private void registerClickHouseEnvironment(ClickHouseContainer clickHouseContainer, ConfigurableEnvironment environment, ClickHouseProperties properties, String username, String password) {
+        Integer mappedPort = clickHouseContainer.getMappedPort(properties.port);
+        String host = clickHouseContainer.getHost();
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.clickhouse.schema", "default");
+        map.put("embedded.clickhouse.host", host);
+        map.put("embedded.clickhouse.port", mappedPort);
+        map.put("embedded.clickhouse.user", username);
+        map.put("embedded.clickhouse.password", password);
+        map.put("embedded.clickhouse.networkAlias", CLICKHOUSE_NETWORK_ALIAS);
+        map.put("embedded.clickhouse.internalPort", properties.getPort());
+
+        log.info("Started ClickHouse server. Connection details: schema=default, host={}, port={}, user={}, password={}, networkAlias={}, internalPort={}",
+                host, mappedPort, username, password, CLICKHOUSE_NETWORK_ALIAS, properties.getPort());
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedClickhouseInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 
 }

--- a/embedded-cockroachdb/src/main/java/com/playtika/testcontainer/cockroach/EmbeddedCockroachDBBootstrapConfiguration.java
+++ b/embedded-cockroachdb/src/main/java/com/playtika/testcontainer/cockroach/EmbeddedCockroachDBBootstrapConfiguration.java
@@ -14,11 +14,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.CockroachContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.cockroach.CockroachDBProperties.BEAN_NAME_EMBEDDED_COCKROACHDB;
@@ -38,18 +40,24 @@ public class EmbeddedCockroachDBBootstrapConfiguration {
     @ConditionalOnToxiProxyEnabled(module = "cockroach")
     ToxiproxyClientProxy cockroachContainerProxy(ToxiproxyClient toxiproxyClient,
                                                   ToxiproxyContainer toxiproxyContainer,
-                                                  @Qualifier(BEAN_NAME_EMBEDDED_COCKROACHDB) CockroachContainer cockroachContainer) {
+                                                  @Qualifier(BEAN_NAME_EMBEDDED_COCKROACHDB) CockroachContainer cockroachContainer,
+                                                  ConfigurableEnvironment environment) {
 
-        return ToxiproxyHelper.createProxy(
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 cockroachContainer,
                 CockroachDBProperties.PORT,
                 "cockroach");
+
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.cockroach", "embeddedCockroachToxiProxyInfo", environment);
+
+        return proxy;
     }
 
     @Bean(name = BEAN_NAME_EMBEDDED_COCKROACHDB, destroyMethod = "stop")
     public CockroachContainer cockroach(CockroachDBProperties properties,
+                                        ConfigurableEnvironment environment,
                                         Optional<Network> network) throws Exception {
         CockroachContainer cockroachContainer = new CockroachContainer(ContainerUtils.getDockerImageName(properties))
                 .withInitScript(properties.getInitScriptPath())
@@ -58,27 +66,21 @@ public class EmbeddedCockroachDBBootstrapConfiguration {
         network.ifPresent(cockroachContainer::withNetwork);
 
         cockroachContainer = (CockroachContainer) configureCommonsAndStart(cockroachContainer, properties, log);
+        registerCockroachEnvironment(cockroachContainer, environment);
         return cockroachContainer;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar cockroachDynamicPropertyRegistrar(
-            @Qualifier(BEAN_NAME_EMBEDDED_COCKROACHDB) CockroachContainer cockroach) {
-        return registry -> {
-            registry.add("embedded.cockroach.port", () -> cockroach.getMappedPort(CockroachDBProperties.PORT));
-            registry.add("embedded.cockroach.host", cockroach::getHost);
-            registry.add("embedded.cockroach.schema", cockroach::getDatabaseName);
-            registry.add("embedded.cockroach.user", cockroach::getUsername);
-            registry.add("embedded.cockroach.password", cockroach::getPassword);
-            registry.add("embedded.cockroach.networkAlias", () -> COCKROACHDB_NETWORK_ALIAS);
-            registry.add("embedded.cockroach.internalPort", () -> CockroachDBProperties.PORT);
-        };
-    }
+    private void registerCockroachEnvironment(CockroachContainer cockroach, ConfigurableEnvironment environment) {
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.cockroach.port", cockroach.getMappedPort(CockroachDBProperties.PORT));
+        map.put("embedded.cockroach.host", cockroach.getHost());
+        map.put("embedded.cockroach.schema", cockroach.getDatabaseName());
+        map.put("embedded.cockroach.user", cockroach.getUsername());
+        map.put("embedded.cockroach.password", cockroach.getPassword());
+        map.put("embedded.cockroach.networkAlias", COCKROACHDB_NETWORK_ALIAS);
+        map.put("embedded.cockroach.internalPort", CockroachDBProperties.PORT);
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "cockroach")
-    public DynamicPropertyRegistrar cockroachToxiProxyDynamicPropertyRegistrar(
-            @Qualifier("cockroachContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.cockroach");
+        MapPropertySource propertySource = new MapPropertySource("embeddedCockroachInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 }

--- a/embedded-consul/src/main/java/com/playtika/testcontainer/consul/EmbeddedConsulBootstrapConfiguration.java
+++ b/embedded-consul/src/main/java/com/playtika/testcontainer/consul/EmbeddedConsulBootstrapConfiguration.java
@@ -14,13 +14,15 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -41,23 +43,22 @@ public class EmbeddedConsulBootstrapConfiguration {
     ToxiproxyClientProxy consulContainerProxy(ToxiproxyClient toxiproxyClient,
                                                ToxiproxyContainer toxiproxyContainer,
                                                @Qualifier(BEAN_NAME_EMBEDDED_CONSUL) GenericContainer<?> consulContainer,
-                                               ConsulProperties properties) {
-        return ToxiproxyHelper.createProxy(
+                                               ConsulProperties properties,
+                                               ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 consulContainer,
                 properties.getPort(),
                 "consul");
-    }
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "consul")
-    public DynamicPropertyRegistrar consulToxiProxyDynamicPropertyRegistrar(@Qualifier("consulContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.consul");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.consul", "embeddedConsulToxiProxyInfo", environment);
+
+        return proxy;
     }
 
     @Bean(name = BEAN_NAME_EMBEDDED_CONSUL, destroyMethod = "stop")
-    public GenericContainer<?> consulContainer(ConsulProperties properties, Optional<Network> network) {
+    public GenericContainer<?> consulContainer(ConsulProperties properties, ConfigurableEnvironment environment, Optional<Network> network) {
         GenericContainer<?> consul = new GenericContainer<>(ContainerUtils.getDockerImageName(properties))
                 .withExposedPorts(properties.getPort())
                 .waitingFor(
@@ -75,16 +76,18 @@ public class EmbeddedConsulBootstrapConfiguration {
         }
 
         consul = configureCommonsAndStart(consul, properties, log);
+        registerConsulEnvironment(consul, environment, properties);
         return consul;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar consulDynamicPropertyRegistrar(@Qualifier(BEAN_NAME_EMBEDDED_CONSUL) GenericContainer<?> consul, ConsulProperties properties) {
-        return registry -> {
-            registry.add("embedded.consul.port", () -> consul.getMappedPort(properties.getPort()));
-            registry.add("embedded.consul.host", consul::getHost);
-            registry.add("embedded.consul.networkAlias", () -> CONSUL_NETWORK_ALIAS);
-            registry.add("embedded.consul.internalPort", properties::getPort);
-        };
+    private void registerConsulEnvironment(GenericContainer<?> consul, ConfigurableEnvironment environment, ConsulProperties properties) {
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.consul.port", consul.getMappedPort(properties.getPort()));
+        map.put("embedded.consul.host", consul.getHost());
+        map.put("embedded.consul.networkAlias", CONSUL_NETWORK_ALIAS);
+        map.put("embedded.consul.internalPort", properties.getPort());
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedConsulInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 }

--- a/embedded-couchbase/src/main/java/com/playtika/testcontainer/couchbase/EmbeddedCouchbaseBootstrapConfiguration.java
+++ b/embedded-couchbase/src/main/java/com/playtika/testcontainer/couchbase/EmbeddedCouchbaseBootstrapConfiguration.java
@@ -17,12 +17,14 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.couchbase.BucketDefinition;
 import org.testcontainers.couchbase.CouchbaseContainer;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -47,17 +49,23 @@ public class EmbeddedCouchbaseBootstrapConfiguration {
     @ConditionalOnToxiProxyEnabled(module = "couchbase")
     ToxiproxyClientProxy couchbaseContainerProxy(ToxiproxyClient toxiproxyClient,
                                                   ToxiproxyContainer toxiproxyContainer,
-                                                  @Qualifier(BEAN_NAME_EMBEDDED_COUCHBASE) CouchbaseContainer couchbase) {
-        return ToxiproxyHelper.createProxy(
+                                                  @Qualifier(BEAN_NAME_EMBEDDED_COUCHBASE) CouchbaseContainer couchbase,
+                                                  ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 couchbase,
                 couchbase.getBootstrapHttpDirectPort(),
                 "couchbase");
+
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.couchbase", "embeddedCouchbaseToxiProxyInfo", environment);
+
+        return proxy;
     }
 
     @Bean(name = BEAN_NAME_EMBEDDED_COUCHBASE, destroyMethod = "stop")
     public CouchbaseContainer couchbase(CouchbaseProperties properties,
+                                        ConfigurableEnvironment environment,
                                         Optional<Network> network) {
         BucketDefinition bucketDefinition = new BucketDefinition(properties.getBucket())
                 .withPrimaryIndex(true)
@@ -71,41 +79,34 @@ public class EmbeddedCouchbaseBootstrapConfiguration {
 
         network.ifPresent(couchbase::withNetwork);
         couchbase = (CouchbaseContainer) configureCommonsAndStart(couchbase, properties, log);
+        registerCouchbaseEnvironment(couchbase, environment, properties);
         return couchbase;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar couchbaseDynamicPropertyRegistrar(
-            @Qualifier(BEAN_NAME_EMBEDDED_COUCHBASE) CouchbaseContainer couchbase,
-            CouchbaseProperties properties) {
-        return registry -> {
-            Integer mappedHttpPort = couchbase.getBootstrapHttpDirectPort();
-            Integer mappedCarrierPort = couchbase.getBootstrapCarrierDirectPort();
-            String host = couchbase.getHost();
+    private void registerCouchbaseEnvironment(CouchbaseContainer couchbase, ConfigurableEnvironment environment, CouchbaseProperties properties) {
+        Integer mappedHttpPort = couchbase.getBootstrapHttpDirectPort();
+        Integer mappedCarrierPort = couchbase.getBootstrapCarrierDirectPort();
+        String host = couchbase.getHost();
 
-            // System properties must be set before client initialization
-            // These are required by Couchbase SDK for auto-discovery
-            System.setProperty("com.couchbase.bootstrapHttpDirectPort", String.valueOf(mappedHttpPort));
-            System.setProperty("com.couchbase.bootstrapCarrierDirectPort", String.valueOf(mappedCarrierPort));
+        // System properties must be set before client initialization
+        // These are required by Couchbase SDK for auto-discovery
+        System.setProperty("com.couchbase.bootstrapHttpDirectPort", String.valueOf(mappedHttpPort));
+        System.setProperty("com.couchbase.bootstrapCarrierDirectPort", String.valueOf(mappedCarrierPort));
 
-            registry.add("embedded.couchbase.bootstrapHttpDirectPort", () -> mappedHttpPort);
-            registry.add("embedded.couchbase.bootstrapCarrierDirectPort", () -> mappedCarrierPort);
-            registry.add("embedded.couchbase.host", () -> host);
-            registry.add("embedded.couchbase.bucket", properties::getBucket);
-            registry.add("embedded.couchbase.user", properties::getUser);
-            registry.add("embedded.couchbase.password", properties::getPassword);
-            registry.add("embedded.couchbase.networkAlias", () -> COUCHBASE_NETWORK_ALIAS);
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.couchbase.bootstrapHttpDirectPort", mappedHttpPort);
+        map.put("embedded.couchbase.bootstrapCarrierDirectPort", mappedCarrierPort);
+        map.put("embedded.couchbase.host", host);
+        map.put("embedded.couchbase.bucket", properties.getBucket());
+        map.put("embedded.couchbase.user", properties.getUser());
+        map.put("embedded.couchbase.password", properties.getPassword());
+        map.put("embedded.couchbase.networkAlias", COUCHBASE_NETWORK_ALIAS);
 
-            log.info("Started couchbase server. Connection details: host={}, httpPort={}, carrierPort={}, user={}, password={}, " +
-                            "Admin UI: http://localhost:{}",
-                    host, mappedHttpPort, mappedCarrierPort, properties.getUser(), properties.getPassword(), mappedHttpPort);
-        };
-    }
+        log.info("Started couchbase server. Connection details: host={}, httpPort={}, carrierPort={}, user={}, password={}, " +
+                        "Admin UI: http://localhost:{}",
+                host, mappedHttpPort, mappedCarrierPort, properties.getUser(), properties.getPassword(), mappedHttpPort);
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "couchbase")
-    public DynamicPropertyRegistrar couchbaseToxiProxyDynamicPropertyRegistrar(
-            @Qualifier("couchbaseContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.couchbase");
+        MapPropertySource propertySource = new MapPropertySource("embeddedCouchbaseInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 }

--- a/embedded-db2/src/main/java/com/playtika/testcontainer/db2/EmbeddedDb2BootstrapConfiguration.java
+++ b/embedded-db2/src/main/java/com/playtika/testcontainer/db2/EmbeddedDb2BootstrapConfiguration.java
@@ -14,13 +14,15 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.springframework.util.StringUtils;
 import org.testcontainers.containers.Db2Container;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -40,23 +42,23 @@ public class EmbeddedDb2BootstrapConfiguration {
     @ConditionalOnToxiProxyEnabled(module = "db2")
     ToxiproxyClientProxy db2ContainerProxy(ToxiproxyClient toxiproxyClient,
                                             ToxiproxyContainer toxiproxyContainer,
-                                            @Qualifier(BEAN_NAME_EMBEDDED_DB2) Db2Container db2) {
-        return ToxiproxyHelper.createProxy(
+                                            @Qualifier(BEAN_NAME_EMBEDDED_DB2) Db2Container db2,
+                                            ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 db2,
                 Db2Container.DB2_PORT,
                 "db2");
-    }
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "db2")
-    public DynamicPropertyRegistrar db2ToxiProxyDynamicPropertyRegistrar(@Qualifier("db2ContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.db2");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.db2", "embeddedDb2ToxiProxyInfo", environment);
+
+        return proxy;
     }
 
     @Bean(name = BEAN_NAME_EMBEDDED_DB2, destroyMethod = "stop")
     public Db2Container db2(Db2Properties properties,
+                            ConfigurableEnvironment environment,
                             Optional<Network> network) {
         Db2Container db2Container = new Db2Container(ContainerUtils.getDockerImageName(properties))
                 .withDatabaseName(properties.getDatabase())
@@ -76,25 +78,29 @@ public class EmbeddedDb2BootstrapConfiguration {
             db2Container = db2Container.withCommand("platform", "linux/amd64");
         }
         db2Container = (Db2Container) configureCommonsAndStart(db2Container, properties, log);
-        Integer mappedPort = db2Container.getMappedPort(Db2Container.DB2_PORT);
-        String host = db2Container.getHost();
-        String jdbcURL = "jdbc:db2://" + host + ":" + mappedPort + "/" + properties.getDatabase();
-        log.info("Started db2 server. Connection details: host={}, port={}, database={}, user={}, password={}, networkAlias={}, internalPort={}, JDBC connection url: {}",
-                host, mappedPort, properties.getDatabase(), properties.getUser(), properties.getPassword(), DB2_NETWORK_ALIAS, Db2Container.DB2_PORT, jdbcURL);
+        registerDb2Environment(db2Container, environment, properties);
         return db2Container;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar db2DynamicPropertyRegistrar(@Qualifier(BEAN_NAME_EMBEDDED_DB2) Db2Container db2Container, Db2Properties properties) {
-        return registry -> {
-            registry.add("embedded.db2.port", () -> db2Container.getMappedPort(Db2Container.DB2_PORT));
-            registry.add("embedded.db2.host", db2Container::getHost);
-            registry.add("embedded.db2.database", properties::getDatabase);
-            registry.add("embedded.db2.user", properties::getUser);
-            registry.add("embedded.db2.password", properties::getPassword);
-            registry.add("embedded.db2.networkAlias", () -> DB2_NETWORK_ALIAS);
-            registry.add("embedded.db2.internalPort", () -> Db2Container.DB2_PORT);
-        };
+    private void registerDb2Environment(Db2Container db2Container, ConfigurableEnvironment environment, Db2Properties properties) {
+        Integer mappedPort = db2Container.getMappedPort(Db2Container.DB2_PORT);
+        String host = db2Container.getHost();
+        String jdbcURL = "jdbc:db2://" + host + ":" + mappedPort + "/" + properties.getDatabase();
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.db2.port", mappedPort);
+        map.put("embedded.db2.host", host);
+        map.put("embedded.db2.database", properties.getDatabase());
+        map.put("embedded.db2.user", properties.getUser());
+        map.put("embedded.db2.password", properties.getPassword());
+        map.put("embedded.db2.networkAlias", DB2_NETWORK_ALIAS);
+        map.put("embedded.db2.internalPort", Db2Container.DB2_PORT);
+
+        log.info("Started db2 server. Connection details: host={}, port={}, database={}, user={}, password={}, networkAlias={}, internalPort={}, JDBC connection url: {}",
+                host, mappedPort, properties.getDatabase(), properties.getUser(), properties.getPassword(), DB2_NETWORK_ALIAS, Db2Container.DB2_PORT, jdbcURL);
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedDb2Info", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 
 }

--- a/embedded-elasticsearch/src/main/java/com/playtika/testcontainer/elasticsearch/EmbeddedElasticSearchBootstrapConfiguration.java
+++ b/embedded-elasticsearch/src/main/java/com/playtika/testcontainer/elasticsearch/EmbeddedElasticSearchBootstrapConfiguration.java
@@ -14,11 +14,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -39,47 +41,51 @@ public class EmbeddedElasticSearchBootstrapConfiguration {
     ToxiproxyClientProxy elasticsearchContainerProxy(ToxiproxyClient toxiproxyClient,
                                                       ToxiproxyContainer toxiproxyContainer,
                                                       @Qualifier(BEAN_NAME_EMBEDDED_ELASTIC_SEARCH) ElasticsearchContainer elasticSearch,
-                                                      ElasticSearchProperties properties) {
-        return ToxiproxyHelper.createProxy(
+                                                      ElasticSearchProperties properties,
+                                                      ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 elasticSearch,
                 properties.getHttpPort(),
                 "elasticsearch");
-    }
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "elasticsearch")
-    public DynamicPropertyRegistrar elasticsearchToxiProxyDynamicPropertyRegistrar(@Qualifier("elasticsearchContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.elasticsearch");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.elasticsearch", "embeddedElasticsearchToxiProxyInfo", environment);
+
+        return proxy;
     }
 
     @ConditionalOnMissingBean(name = BEAN_NAME_EMBEDDED_ELASTIC_SEARCH)
     @Bean(name = BEAN_NAME_EMBEDDED_ELASTIC_SEARCH, destroyMethod = "stop")
     public ElasticsearchContainer elasticSearch(ElasticSearchProperties properties,
+                                                ConfigurableEnvironment environment,
                                                 Optional<Network> network) {
         ElasticsearchContainer elasticSearch = ElasticSearchContainerFactory.create(properties)
                 .withNetworkAliases(ELASTICSEARCH_NETWORK_ALIAS);
         network.ifPresent(elasticSearch::withNetwork);
         elasticSearch = (ElasticsearchContainer) configureCommonsAndStart(elasticSearch, properties, log);
-        Integer httpPort = elasticSearch.getMappedPort(properties.getHttpPort());
-        Integer transportPort = elasticSearch.getMappedPort(properties.getTransportPort());
-        String host = elasticSearch.getHost();
-        log.info("Started ElasticSearch server. Connection details: clusterName={}, host={}, httpPort={}, transportPort={}, networkAlias={}, internalHttpPort={}, internalTransportPort={}",
-                properties.getClusterName(), host, httpPort, transportPort, ELASTICSEARCH_NETWORK_ALIAS, properties.getHttpPort(), properties.getTransportPort());
+        registerElasticsearchEnvironment(elasticSearch, environment, properties);
         return elasticSearch;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar elasticsearchDynamicPropertyRegistrar(@Qualifier(BEAN_NAME_EMBEDDED_ELASTIC_SEARCH) ElasticsearchContainer elasticSearch, ElasticSearchProperties properties) {
-        return registry -> {
-            registry.add("embedded.elasticsearch.clusterName", properties::getClusterName);
-            registry.add("embedded.elasticsearch.host", elasticSearch::getHost);
-            registry.add("embedded.elasticsearch.httpPort", () -> elasticSearch.getMappedPort(properties.getHttpPort()));
-            registry.add("embedded.elasticsearch.transportPort", () -> elasticSearch.getMappedPort(properties.getTransportPort()));
-            registry.add("embedded.elasticsearch.networkAlias", () -> ELASTICSEARCH_NETWORK_ALIAS);
-            registry.add("embedded.elasticsearch.internalHttpPort", properties::getHttpPort);
-            registry.add("embedded.elasticsearch.internalTransportPort", properties::getTransportPort);
-        };
+    private void registerElasticsearchEnvironment(ElasticsearchContainer elasticSearch, ConfigurableEnvironment environment, ElasticSearchProperties properties) {
+        Integer httpPort = elasticSearch.getMappedPort(properties.getHttpPort());
+        Integer transportPort = elasticSearch.getMappedPort(properties.getTransportPort());
+        String host = elasticSearch.getHost();
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.elasticsearch.clusterName", properties.getClusterName());
+        map.put("embedded.elasticsearch.host", host);
+        map.put("embedded.elasticsearch.httpPort", httpPort);
+        map.put("embedded.elasticsearch.transportPort", transportPort);
+        map.put("embedded.elasticsearch.networkAlias", ELASTICSEARCH_NETWORK_ALIAS);
+        map.put("embedded.elasticsearch.internalHttpPort", properties.getHttpPort());
+        map.put("embedded.elasticsearch.internalTransportPort", properties.getTransportPort());
+
+        log.info("Started ElasticSearch server. Connection details: clusterName={}, host={}, httpPort={}, transportPort={}, networkAlias={}, internalHttpPort={}, internalTransportPort={}",
+                properties.getClusterName(), host, httpPort, transportPort, ELASTICSEARCH_NETWORK_ALIAS, properties.getHttpPort(), properties.getTransportPort());
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedElasticsearchInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 }

--- a/embedded-git/src/main/java/com/playtika/testcontainer/git/EmbeddedGitBootstrapConfiguration.java
+++ b/embedded-git/src/main/java/com/playtika/testcontainer/git/EmbeddedGitBootstrapConfiguration.java
@@ -15,12 +15,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -44,40 +46,42 @@ public class EmbeddedGitBootstrapConfiguration {
     ToxiproxyClientProxy gitContainerProxy(ToxiproxyClient toxiproxyClient,
                                             ToxiproxyContainer toxiproxyContainer,
                                             @Qualifier(BEAN_NAME_EMBEDDED_GIT) GenericContainer<?> embeddedGit,
-                                           GitProperties gitProperties) {
-        return ToxiproxyHelper.createProxy(
+                                            GitProperties gitProperties,
+                                            ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 embeddedGit,
                 gitProperties.getPort(),
                 "git");
-    }
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "git")
-    public DynamicPropertyRegistrar gitToxiProxyDynamicPropertyRegistrar(@Qualifier("gitContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.git");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.git", "embeddedGitToxiProxyInfo", environment);
+
+        return proxy;
     }
 
     @ConditionalOnMissingBean(name = BEAN_NAME_EMBEDDED_GIT)
     @Bean(name = BEAN_NAME_EMBEDDED_GIT, destroyMethod = "stop")
-    public GenericContainer<?> embeddedGit(GitProperties properties, Optional<Network> network) {
+    public GenericContainer<?> embeddedGit(GitProperties properties, ConfigurableEnvironment environment, Optional<Network> network) {
         GenericContainer<?> gitContainer = configureCommonsAndStart(createContainer(properties, network), properties, log);
+        registerGitEnvironment(gitContainer, environment, properties);
         return gitContainer;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar gitDynamicPropertyRegistrar(@Qualifier(BEAN_NAME_EMBEDDED_GIT) GenericContainer<?> gitContainer, GitProperties properties) {
-        return registry -> {
-            Integer mappedPort = gitContainer.getMappedPort(properties.getPort());
-            String host = gitContainer.getHost();
-            String password = properties.getPassword();
-            registry.add("embedded.git.port", () -> mappedPort);
-            registry.add("embedded.git.host", () -> host);
-            registry.add("embedded.git.password", () -> password);
-            registry.add("embedded.git.networkAlias", () -> GIT_NETWORK_ALIAS);
-            registry.add("embedded.git.internalPort", properties::getPort);
-        };
+    private void registerGitEnvironment(GenericContainer<?> gitContainer, ConfigurableEnvironment environment, GitProperties properties) {
+        Integer mappedPort = gitContainer.getMappedPort(properties.getPort());
+        String host = gitContainer.getHost();
+        String password = properties.getPassword();
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.git.port", mappedPort);
+        map.put("embedded.git.host", host);
+        map.put("embedded.git.password", password);
+        map.put("embedded.git.networkAlias", GIT_NETWORK_ALIAS);
+        map.put("embedded.git.internalPort", properties.getPort());
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedGitInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 
     private GenericContainer<?> createContainer(GitProperties properties, Optional<Network> network) {

--- a/embedded-google-pubsub/src/main/java/com/playtika/testcontainer/pubsub/EmbeddedPubsubBootstrapConfiguration.java
+++ b/embedded-google-pubsub/src/main/java/com/playtika/testcontainer/pubsub/EmbeddedPubsubBootstrapConfiguration.java
@@ -16,13 +16,15 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -46,18 +48,23 @@ public class EmbeddedPubsubBootstrapConfiguration {
     ToxiproxyClientProxy googlePubSubContainerProxy(ToxiproxyClient toxiproxyClient,
                                                      ToxiproxyContainer toxiproxyContainer,
                                                      @Qualifier(BEAN_NAME_EMBEDDED_GOOGLE_PUBSUB) GenericContainer<?> pubsub,
-                                                     PubsubProperties properties) {
-        return ToxiproxyHelper.createProxy(
+                                                     PubsubProperties properties,
+                                                     ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 pubsub,
                 properties.getPort(),
                 "pubsub");
+
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.google.pubsub", "embeddedPubsubToxiProxyInfo", environment);
+
+        return proxy;
     }
 
 
     @Bean(name = BEAN_NAME_EMBEDDED_GOOGLE_PUBSUB, destroyMethod = "stop")
-    public GenericContainer<?> pubsub(PubsubProperties properties, Optional<Network> network) {
+    public GenericContainer<?> pubsub(PubsubProperties properties, ConfigurableEnvironment environment, Optional<Network> network) {
         GenericContainer<?> pubsubContainer = new GenericContainer<>(ContainerUtils.getDockerImageName(properties))
             .withExposedPorts(properties.getPort())
             .withCommand(
@@ -84,44 +91,38 @@ public class EmbeddedPubsubBootstrapConfiguration {
         System.setProperty("spring.cloud.gcp.pubsub.emulatorHost", emulatorHost);
         System.setProperty("spring.cloud.gcp.pubsub.emulator-host", emulatorHost);
 
+        registerPubsubEnvironment(pubsubContainer, environment, properties);
+
         return pubsubContainer;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar pubsubDynamicPropertyRegistrar(
-            @Qualifier(BEAN_NAME_EMBEDDED_GOOGLE_PUBSUB) GenericContainer<?> container,
-            PubsubProperties properties) {
-        return registry -> {
-            String host = container.getHost();
-            Integer port = container.getMappedPort(properties.getPort());
-            String emulatorHost = format("%s:%d", host, port);
+    private void registerPubsubEnvironment(GenericContainer<?> container, ConfigurableEnvironment environment, PubsubProperties properties) {
+        String host = container.getHost();
+        Integer port = container.getMappedPort(properties.getPort());
+        String emulatorHost = format("%s:%d", host, port);
 
-            registry.add("embedded.google.pubsub.port", () -> port);
-            registry.add("embedded.google.pubsub.host", () -> host);
-            registry.add("embedded.google.pubsub.project-id", properties::getProjectId);
-            registry.add("embedded.google.pubsub.networkAlias", () -> GOOGLE_PUB_SUB_NETWORK_ALIAS);
-            registry.add("embedded.google.pubsub.internalPort", properties::getPort);
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.google.pubsub.port", port);
+        map.put("embedded.google.pubsub.host", host);
+        map.put("embedded.google.pubsub.project-id", properties.getProjectId());
+        map.put("embedded.google.pubsub.networkAlias", GOOGLE_PUB_SUB_NETWORK_ALIAS);
+        map.put("embedded.google.pubsub.internalPort", properties.getPort());
 
-            // Register Spring Cloud GCP properties for auto-configuration
-            // Support both camelCase and kebab-case property names
-            registry.add("spring.cloud.gcp.pubsub.emulatorHost", () -> emulatorHost);
-            registry.add("spring.cloud.gcp.pubsub.emulator-host", () -> emulatorHost);
-            registry.add("spring.cloud.gcp.project-id", properties::getProjectId);
+        // Register Spring Cloud GCP properties for auto-configuration
+        // Support both camelCase and kebab-case property names
+        map.put("spring.cloud.gcp.pubsub.emulatorHost", emulatorHost);
+        map.put("spring.cloud.gcp.pubsub.emulator-host", emulatorHost);
+        map.put("spring.cloud.gcp.project-id", properties.getProjectId());
 
-            // Set PUBSUB_EMULATOR_HOST system property for Google Cloud SDK clients
-            System.setProperty("PUBSUB_EMULATOR_HOST", emulatorHost);
+        // Set PUBSUB_EMULATOR_HOST system property for Google Cloud SDK clients
+        System.setProperty("PUBSUB_EMULATOR_HOST", emulatorHost);
 
-            log.info("Started Google Cloud Pubsub emulator. Connection details: host={}, port={}, project-id={}",
-                    host, port, properties.getProjectId());
-            log.info("Consult with the doc https://cloud.google.com/pubsub/docs/emulator for more details");
-        };
-    }
+        log.info("Started Google Cloud Pubsub emulator. Connection details: host={}, port={}, project-id={}",
+                host, port, properties.getProjectId());
+        log.info("Consult with the doc https://cloud.google.com/pubsub/docs/emulator for more details");
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "google.pubsub")
-    public DynamicPropertyRegistrar pubsubToxiProxyDynamicPropertyRegistrar(
-            @Qualifier("googlePubSubContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.google.pubsub");
+        MapPropertySource propertySource = new MapPropertySource("embeddedPubsubInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 
     @Bean(name = BEAN_NAME_EMBEDDED_GOOGLE_PUBSUB_MANAGED_CHANNEL)

--- a/embedded-google-storage/src/main/java/com/playtika/testcontainer/storage/EmbeddedStorageBootstrapConfiguration.java
+++ b/embedded-google-storage/src/main/java/com/playtika/testcontainer/storage/EmbeddedStorageBootstrapConfiguration.java
@@ -15,12 +15,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -42,23 +44,22 @@ public class EmbeddedStorageBootstrapConfiguration {
     @ConditionalOnToxiProxyEnabled(module = "google.storage")
     ToxiproxyClientProxy googleStorageContainerProxy(ToxiproxyClient toxiproxyClient,
                                                       ToxiproxyContainer toxiproxyContainer,
-                                                      @Qualifier(BEAN_NAME_EMBEDDED_GOOGLE_STORAGE_SERVER) GenericContainer<?> storageServer) {
-        return ToxiproxyHelper.createProxy(
+                                                      @Qualifier(BEAN_NAME_EMBEDDED_GOOGLE_STORAGE_SERVER) GenericContainer<?> storageServer,
+                                                      ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 storageServer,
                 StorageProperties.PORT,
                 "storage");
-    }
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "google.storage")
-    public DynamicPropertyRegistrar googleStorageToxiProxyDynamicPropertyRegistrar(@Qualifier("googleStorageContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.google.storage");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.google.storage", "embeddedStorageToxiProxyInfo", environment);
+
+        return proxy;
     }
 
     @Bean(name = BEAN_NAME_EMBEDDED_GOOGLE_STORAGE_SERVER, destroyMethod = "stop")
-    public GenericContainer<?> storageServer(StorageProperties properties, Optional<Network> network) throws IOException {
+    public GenericContainer<?> storageServer(StorageProperties properties, ConfigurableEnvironment environment, Optional<Network> network) throws IOException {
         GenericContainer<?> storageContainer = new GenericContainer<>(ContainerUtils.getDockerImageName(properties))
                 .withExposedPorts(StorageProperties.PORT)
                 .withCreateContainerCmdModifier(cmd -> cmd.withEntrypoint(
@@ -75,20 +76,22 @@ public class EmbeddedStorageBootstrapConfiguration {
 
         storageContainer = configureCommonsAndStart(storageContainer, properties, log);
         prepareContainerConfiguration(storageContainer);
+        registerStorageEnvironment(storageContainer, environment, properties);
         return storageContainer;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar googleStorageDynamicPropertyRegistrar(@Qualifier(BEAN_NAME_EMBEDDED_GOOGLE_STORAGE_SERVER) GenericContainer<?> container, StorageProperties properties) {
-        return registry -> {
-            registry.add("embedded.google.storage.host", container::getHost);
-            registry.add("embedded.google.storage.port", () -> container.getMappedPort(StorageProperties.PORT));
-            registry.add("embedded.google.storage.endpoint", () -> buildContainerEndpoint(container));
-            registry.add("embedded.google.storage.project-id", properties::getProjectId);
-            registry.add("embedded.google.storage.bucket-location", properties::getBucketLocation);
-            registry.add("embedded.google.storage.networkAlias", () -> GOOGLE_STORAGE_NETWORK_ALIAS);
-            registry.add("embedded.google.storage.internalPort", () -> StorageProperties.PORT);
-        };
+    private void registerStorageEnvironment(GenericContainer<?> container, ConfigurableEnvironment environment, StorageProperties properties) {
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.google.storage.host", container.getHost());
+        map.put("embedded.google.storage.port", container.getMappedPort(StorageProperties.PORT));
+        map.put("embedded.google.storage.endpoint", buildContainerEndpoint(container));
+        map.put("embedded.google.storage.project-id", properties.getProjectId());
+        map.put("embedded.google.storage.bucket-location", properties.getBucketLocation());
+        map.put("embedded.google.storage.networkAlias", GOOGLE_STORAGE_NETWORK_ALIAS);
+        map.put("embedded.google.storage.internalPort", StorageProperties.PORT);
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedStorageInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 
     private void prepareContainerConfiguration(GenericContainer<?> container) throws IOException {

--- a/embedded-grafana/src/main/java/com/playtika/testcontainer/grafana/EmbeddedGrafanaBootstrapConfiguration.java
+++ b/embedded-grafana/src/main/java/com/playtika/testcontainer/grafana/EmbeddedGrafanaBootstrapConfiguration.java
@@ -15,13 +15,15 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -51,17 +53,21 @@ public class EmbeddedGrafanaBootstrapConfiguration {
     ToxiproxyClientProxy grafanaContainerProxy(ToxiproxyClient toxiproxyClient,
                                                 ToxiproxyContainer toxiproxyContainer,
                                                 @Qualifier(GRAFANA_BEAN_NAME) GenericContainer<?> grafana,
-                                                GrafanaProperties properties) {
-        return ToxiproxyHelper.createProxy(
+                                                GrafanaProperties properties,
+                                                ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 grafana,
                 properties.getPort(),
                 "grafana");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.grafana", "embeddedGrafanaToxiProxyInfo", environment);
+        return proxy;
     }
 
     @Bean(name = GRAFANA_BEAN_NAME, destroyMethod = "stop")
-    public GenericContainer<?> grafana(GrafanaProperties properties,
+    public GenericContainer<?> grafana(ConfigurableEnvironment environment,
+                                       GrafanaProperties properties,
                                        WaitStrategy grafanaWaitStrategy,
                                        Optional<Network> network) {
         GenericContainer<?> container =
@@ -76,27 +82,22 @@ public class EmbeddedGrafanaBootstrapConfiguration {
         network.ifPresent(container::withNetwork);
 
         configureCommonsAndStart(container, properties, log);
+        registerGrafanaEnvironment(container, environment, properties);
         return container;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar grafanaDynamicPropertyRegistrar(
-            @Qualifier(GRAFANA_BEAN_NAME) GenericContainer<?> grafana,
-            GrafanaProperties properties) {
-        return registry -> {
-            registry.add("embedded.grafana.host", grafana::getHost);
-            registry.add("embedded.grafana.port", () -> grafana.getMappedPort(properties.port));
-            registry.add("embedded.grafana.username", properties::getUsername);
-            registry.add("embedded.grafana.password", properties::getPassword);
-            registry.add("embedded.grafana.networkAlias", () -> GRAFANA_NETWORK_ALIAS);
-            registry.add("embedded.grafana.internalPort", properties::getPort);
-        };
-    }
+    private void registerGrafanaEnvironment(GenericContainer<?> grafana,
+                                            ConfigurableEnvironment environment,
+                                            GrafanaProperties properties) {
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.grafana.host", grafana.getHost());
+        map.put("embedded.grafana.port", grafana.getMappedPort(properties.port));
+        map.put("embedded.grafana.username", properties.getUsername());
+        map.put("embedded.grafana.password", properties.getPassword());
+        map.put("embedded.grafana.networkAlias", GRAFANA_NETWORK_ALIAS);
+        map.put("embedded.grafana.internalPort", properties.getPort());
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "grafana")
-    public DynamicPropertyRegistrar grafanaToxiProxyDynamicPropertyRegistrar(
-            @Qualifier("grafanaContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.grafana");
+        MapPropertySource propertySource = new MapPropertySource("embeddedGrafanaInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 }

--- a/embedded-influxdb/src/main/java/com/playtika/testcontainer/influxdb/EmbeddedInfluxDBBootstrapConfiguration.java
+++ b/embedded-influxdb/src/main/java/com/playtika/testcontainer/influxdb/EmbeddedInfluxDBBootstrapConfiguration.java
@@ -14,7 +14,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.InfluxDBContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
@@ -22,6 +23,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
 import org.testcontainers.utility.DockerImageName;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -42,24 +44,22 @@ public class EmbeddedInfluxDBBootstrapConfiguration {
     ToxiproxyClientProxy influxdbContainerProxy(ToxiproxyClient toxiproxyClient,
                                                  ToxiproxyContainer toxiproxyContainer,
                                                  @Qualifier(EMBEDDED_INFLUX_DB) ConcreteInfluxDbContainer influxdb,
-                                                 InfluxDBProperties properties) {
-        return ToxiproxyHelper.createProxy(
+                                                 InfluxDBProperties properties,
+                                                 ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 influxdb,
                 properties.getPort(),
                 "influxdb");
-    }
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "influxdb")
-    public DynamicPropertyRegistrar influxdbToxiProxyDynamicPropertyRegistrar(
-        @Qualifier("influxdbContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.influxdb");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.influxdb", "embeddedInfluxdbToxiProxyInfo", environment);
+
+        return proxy;
     }
 
     @Bean(name = EMBEDDED_INFLUX_DB, destroyMethod = "stop")
-    public ConcreteInfluxDbContainer influxdb(InfluxDBProperties properties, Optional<Network> network) {
+    public ConcreteInfluxDbContainer influxdb(InfluxDBProperties properties, ConfigurableEnvironment environment, Optional<Network> network) {
         ConcreteInfluxDbContainer influxDBContainer = new ConcreteInfluxDbContainer(ContainerUtils.getDockerImageName(properties));
         influxDBContainer
                 .withAdmin(properties.getAdminUser())
@@ -76,22 +76,25 @@ public class EmbeddedInfluxDBBootstrapConfiguration {
         influxDBContainer.waitingFor(getInfluxWaitStrategy(properties.getUser(), properties.getPassword()));
 
         influxDBContainer = (ConcreteInfluxDbContainer) configureCommonsAndStart(influxDBContainer, properties, log);
+        registerInfluxDbEnvironment(influxDBContainer, environment, properties);
         return influxDBContainer;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar influxdbDynamicPropertyRegistrar(@Qualifier(EMBEDDED_INFLUX_DB) ConcreteInfluxDbContainer influx, InfluxDBProperties properties) {
-        return registry -> {
-            Integer mappedPort = influx.getMappedPort(properties.getPort());
-            String host = influx.getHost();
-            registry.add("embedded.influxdb.port", () -> mappedPort);
-            registry.add("embedded.influxdb.host", () -> host);
-            registry.add("embedded.influxdb.database", properties::getDatabase);
-            registry.add("embedded.influxdb.user", properties::getUser);
-            registry.add("embedded.influxdb.password", properties::getPassword);
-            registry.add("embedded.influxdb.networkAlias", () -> INFLUXDB_NETWORK_ALIAS);
-            registry.add("embedded.influxdb.internalPort", properties::getPort);
-        };
+    private void registerInfluxDbEnvironment(ConcreteInfluxDbContainer influx, ConfigurableEnvironment environment, InfluxDBProperties properties) {
+        Integer mappedPort = influx.getMappedPort(properties.getPort());
+        String host = influx.getHost();
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.influxdb.port", mappedPort);
+        map.put("embedded.influxdb.host", host);
+        map.put("embedded.influxdb.database", properties.getDatabase());
+        map.put("embedded.influxdb.user", properties.getUser());
+        map.put("embedded.influxdb.password", properties.getPassword());
+        map.put("embedded.influxdb.networkAlias", INFLUXDB_NETWORK_ALIAS);
+        map.put("embedded.influxdb.internalPort", properties.getPort());
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedInfluxDbInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 
     private WaitAllStrategy getInfluxWaitStrategy(String user, String password) {

--- a/embedded-k3s/src/main/java/com/playtika/testcontainer/k3s/EmbeddedK3sBootstrapConfiguration.java
+++ b/embedded-k3s/src/main/java/com/playtika/testcontainer/k3s/EmbeddedK3sBootstrapConfiguration.java
@@ -3,18 +3,19 @@ package com.playtika.testcontainer.k3s;
 import com.playtika.testcontainer.common.spring.DockerPresenceBootstrapConfiguration;
 import com.playtika.testcontainer.common.utils.ContainerUtils;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.k3s.K3sContainer;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -32,6 +33,7 @@ public class EmbeddedK3sBootstrapConfiguration {
 
     @Bean(name = EMBEDDED_K3S, destroyMethod = "stop")
     public K3sContainer k3s(K3sProperties properties,
+                            ConfigurableEnvironment environment,
                             Optional<Network> network) {
         K3sContainer k3sContainer = new K3sContainer(ContainerUtils.getDockerImageName(properties));
         k3sContainer
@@ -44,17 +46,19 @@ public class EmbeddedK3sBootstrapConfiguration {
 
         k3sContainer = (K3sContainer) configureCommonsAndStart(k3sContainer, properties, log);
         log.info("Started K3s");
+        registerK3sEnvironment(k3sContainer, environment, properties);
 
         return k3sContainer;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar k3sDynamicPropertyRegistrar(@Qualifier(EMBEDDED_K3S) K3sContainer k3s, K3sProperties properties) {
-        return registry -> {
-            registry.add("embedded.k3s.kubeconfig", k3s::getKubeConfigYaml);
-            registry.add("embedded.k3s.networkAlias", () -> K3S_NETWORK_ALIAS);
-            registry.add("embedded.k3s.internalPort", properties::getPort);
-        };
+    private void registerK3sEnvironment(K3sContainer k3s, ConfigurableEnvironment environment, K3sProperties properties) {
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.k3s.kubeconfig", k3s.getKubeConfigYaml());
+        map.put("embedded.k3s.networkAlias", K3S_NETWORK_ALIAS);
+        map.put("embedded.k3s.internalPort", properties.getPort());
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedK3sInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 
 }

--- a/embedded-kafka/src/main/java/com/playtika/testcontainer/kafka/configuration/KafkaContainerConfiguration.java
+++ b/embedded-kafka/src/main/java/com/playtika/testcontainer/kafka/configuration/KafkaContainerConfiguration.java
@@ -19,7 +19,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.KafkaContainer;
@@ -38,6 +39,7 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -75,48 +77,46 @@ public class KafkaContainerConfiguration {
     @ConditionalOnToxiProxyEnabled(module = "kafka")
     ToxiproxyClientProxy kafkaContainerPlainTextProxy(ToxiproxyClient toxiproxyClient,
                                                        ToxiproxyContainer toxiproxyContainer,
-                                                       KafkaConfigurationProperties properties) {
-        return ToxiproxyHelper.createProxy(
+                                                       KafkaConfigurationProperties properties,
+                                                       ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 KAFKA_HOST_NAME,
                 properties.getToxiProxyContainerBrokerPort(),
                 "kafka-plaintext"
         );
-    }
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "kafka")
-    public DynamicPropertyRegistrar kafkaPlainTextToxiProxyDynamicPropertyRegistrar(@Qualifier(KAFKA_PLAIN_TEXT_TOXI_PROXY_BEAN_NAME) ToxiproxyClientProxy proxy) {
-        return registry -> {
-            registry.add("embedded.kafka.toxiproxy.brokerList", () ->
-                format("%s:%d", proxy.getContainerIpAddress(), proxy.getProxyPort()));
-            registry.add("embedded.kafka.toxiproxy.proxyName", proxy::getName);
-        };
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.kafka.toxiproxy.brokerList", format("%s:%d", proxy.getContainerIpAddress(), proxy.getProxyPort()));
+        map.put("embedded.kafka.toxiproxy.proxyName", proxy.getName());
+        MapPropertySource propertySource = new MapPropertySource("embeddedKafkaPlainTextToxiProxyInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
+
+        return proxy;
     }
 
     @Bean(name = KAFKA_SASL_TOXI_PROXY_BEAN_NAME)
     @ConditionalOnToxiProxyEnabled(module = "kafka")
     ToxiproxyClientProxy kafkaContainerSaslProxy(ToxiproxyClient toxiproxyClient,
                                                   ToxiproxyContainer toxiproxyContainer,
-                                                  KafkaConfigurationProperties properties) {
-        return ToxiproxyHelper.createProxy(
+                                                  KafkaConfigurationProperties properties,
+                                                  ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 KAFKA_HOST_NAME,
                 properties.getToxiProxySaslPlaintextContainerBrokerPort(),
                 "kafka-sasl"
         );
-    }
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "kafka")
-    public DynamicPropertyRegistrar kafkaSaslToxiProxyDynamicPropertyRegistrar(@Qualifier(KAFKA_SASL_TOXI_PROXY_BEAN_NAME) ToxiproxyClientProxy proxy) {
-        return registry -> {
-            registry.add("embedded.kafka.toxiproxy.saslPlaintext.brokerList", () ->
-                format("%s:%d", proxy.getContainerIpAddress(), proxy.getProxyPort()));
-            registry.add("embedded.kafka.toxiproxy.saslPlaintext.proxyName", proxy::getName);
-        };
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.kafka.toxiproxy.saslPlaintext.brokerList", format("%s:%d", proxy.getContainerIpAddress(), proxy.getProxyPort()));
+        map.put("embedded.kafka.toxiproxy.saslPlaintext.proxyName", proxy.getName());
+        MapPropertySource propertySource = new MapPropertySource("embeddedKafkaSaslToxiProxyInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
+
+        return proxy;
     }
 
     @Bean(name = KAFKA_BEAN_NAME, destroyMethod = "stop")
@@ -125,6 +125,7 @@ public class KafkaContainerConfiguration {
             KafkaConfigurationProperties kafkaProperties,
             ZookeeperConfigurationProperties zookeeperProperties,
             Network network,
+            ConfigurableEnvironment environment,
             @Autowired(required = false) @Qualifier(KAFKA_PLAIN_TEXT_TOXI_PROXY_BEAN_NAME)
                     ToxiproxyClientProxy plainTextProxy,
             @Autowired(required = false) @Qualifier(KAFKA_SASL_TOXI_PROXY_BEAN_NAME)
@@ -208,7 +209,33 @@ public class KafkaContainerConfiguration {
         zookeeperFileSystemBind(zookeeperProperties, kafka);
 
         kafka = (KafkaContainer) configureCommonsAndStart(kafka, kafkaProperties, log);
+        registerKafkaEnvironment(kafka, environment, kafkaProperties);
         return kafka;
+    }
+
+    private void registerKafkaEnvironment(GenericContainer<?> kafka, ConfigurableEnvironment environment, KafkaConfigurationProperties kafkaProperties) {
+        String host = kafka.getHost();
+        Integer mappedBrokerPort = kafka.getMappedPort(kafkaProperties.getBrokerPort());
+        String kafkaBrokerList = format("%s:%d", host, mappedBrokerPort);
+
+        Integer mappedSaslBrokerPort = kafka.getMappedPort(kafkaProperties.getSaslPlaintextBrokerPort());
+        String saslPlaintextKafkaBrokerList = format("%s:%d", host, mappedSaslBrokerPort);
+
+        Integer containerPort = kafkaProperties.getContainerBrokerPort();
+        String kafkaBrokerListForContainers = format("%s:%d", KAFKA_HOST_NAME, containerPort);
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.kafka.brokerList", kafkaBrokerList);
+        map.put("embedded.kafka.saslPlaintext.brokerList", saslPlaintextKafkaBrokerList);
+        map.put("embedded.kafka.saslPlaintext.user", KafkaConfigurationProperties.KAFKA_USER);
+        map.put("embedded.kafka.saslPlaintext.password", KafkaConfigurationProperties.KAFKA_PASSWORD);
+        map.put("embedded.kafka.networkAlias", KAFKA_HOST_NAME);
+        map.put("embedded.kafka.internalPort", kafkaProperties.getInternalBrokerPort());
+        map.put("embedded.kafka.internalSaslPlaintextPort", kafkaProperties.getInternalSaslPlaintextBrokerPort());
+        map.put("embedded.kafka.containerBrokerList", kafkaBrokerListForContainers);
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedKafkaInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 
     private void kafkaFileSystemBind(KafkaConfigurationProperties kafkaProperties, KafkaContainer kafka) {
@@ -242,29 +269,6 @@ public class KafkaContainerConfiguration {
             createPathAndParentOrMakeWritable(zkTransactionLogs);
             kafka.addFileSystemBind(zkTransactionLogs.toString(), "/var/lib/zookeeper/log", BindMode.READ_WRITE);
         }
-    }
-
-    @Bean
-    public DynamicPropertyRegistrar kafkaDynamicPropertyRegistrar(@Qualifier(KAFKA_BEAN_NAME) GenericContainer<?> kafka, KafkaConfigurationProperties kafkaProperties) {
-        return registry -> {
-            String host = kafka.getHost();
-            Integer mappedBrokerPort = kafka.getMappedPort(kafkaProperties.getBrokerPort());
-            String kafkaBrokerList = format("%s:%d", host, mappedBrokerPort);
-            registry.add("embedded.kafka.brokerList", () -> kafkaBrokerList);
-
-            Integer mappedSaslBrokerPort = kafka.getMappedPort(kafkaProperties.getSaslPlaintextBrokerPort());
-            String saslPlaintextKafkaBrokerList = format("%s:%d", host, mappedSaslBrokerPort);
-            registry.add("embedded.kafka.saslPlaintext.brokerList", () -> saslPlaintextKafkaBrokerList);
-            registry.add("embedded.kafka.saslPlaintext.user", () -> KafkaConfigurationProperties.KAFKA_USER);
-            registry.add("embedded.kafka.saslPlaintext.password", () -> KafkaConfigurationProperties.KAFKA_PASSWORD);
-            registry.add("embedded.kafka.networkAlias", () -> KAFKA_HOST_NAME);
-            registry.add("embedded.kafka.internalPort", kafkaProperties::getInternalBrokerPort);
-            registry.add("embedded.kafka.internalSaslPlaintextPort", kafkaProperties::getInternalSaslPlaintextBrokerPort);
-
-            Integer containerPort = kafkaProperties.getContainerBrokerPort();
-            String kafkaBrokerListForContainers = format("%s:%d", KAFKA_HOST_NAME, containerPort);
-            registry.add("embedded.kafka.containerBrokerList", () -> kafkaBrokerListForContainers);
-        };
     }
 
     /**

--- a/embedded-kafka/src/main/java/com/playtika/testcontainer/kafka/configuration/SchemaRegistryContainerConfiguration.java
+++ b/embedded-kafka/src/main/java/com/playtika/testcontainer/kafka/configuration/SchemaRegistryContainerConfiguration.java
@@ -9,7 +9,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 
@@ -34,7 +35,8 @@ public class SchemaRegistryContainerConfiguration {
             SchemaRegistryConfigurationProperties properties,
             @Qualifier(KAFKA_BEAN_NAME) GenericContainer<?> kafka,
             KafkaConfigurationProperties kafkaProperties,
-            Network network) {
+            Network network,
+            ConfigurableEnvironment environment) {
 
         String kafkaContainerBrokerList = String.format("%s:%d", KAFKA_HOST_NAME, kafkaProperties.getContainerBrokerPort());
 
@@ -59,11 +61,11 @@ public class SchemaRegistryContainerConfiguration {
         }
 
         schemaRegistry = configureCommonsAndStart(schemaRegistry, properties, log);
-        registerSchemaRegistryEnvironment(schemaRegistry, properties);
+        registerSchemaRegistryEnvironment(schemaRegistry, properties, environment);
         return schemaRegistry;
     }
 
-    private void registerSchemaRegistryEnvironment(GenericContainer<?> schemaRegistry, SchemaRegistryConfigurationProperties properties) {
+    private void registerSchemaRegistryEnvironment(GenericContainer<?> schemaRegistry, SchemaRegistryConfigurationProperties properties, ConfigurableEnvironment environment) {
 
         String host = schemaRegistry.getHost();
         Integer port = schemaRegistry.getMappedPort(properties.getPort());
@@ -77,24 +79,8 @@ public class SchemaRegistryContainerConfiguration {
         }
 
         log.info("Started Schema Registry. Connection Details: {}, Connection URI: http://{}:{}", map, host, port);
-    }
 
-    @Bean
-    public DynamicPropertyRegistrar schemaRegistryDynamicPropertyRegistrar(@Qualifier(SCHEMA_REGISTRY_BEAN_NAME) GenericContainer<?> schemaRegistry, SchemaRegistryConfigurationProperties properties) {
-        return registry -> {
-            String host = schemaRegistry.getHost();
-            Integer port = schemaRegistry.getMappedPort(properties.getPort());
-            registry.add("embedded.kafka.schema-registry.host", () -> host);
-            registry.add("embedded.kafka.schema-registry.port", () -> port);
-            if (properties.isBasicAuthenticationEnabled()) {
-                registry.add("embedded.kafka.schema-registry.username", () -> SchemaRegistryConfigurationProperties.USERNAME);
-                registry.add("embedded.kafka.schema-registry.password", () -> SchemaRegistryConfigurationProperties.PASSWORD);
-            }
-            log.info("Started Schema Registry. Connection Details: host={}, port={}, username={}, password={}, Connection URI: http://{}:{}",
-                host, port,
-                properties.isBasicAuthenticationEnabled() ? SchemaRegistryConfigurationProperties.USERNAME : null,
-                properties.isBasicAuthenticationEnabled() ? SchemaRegistryConfigurationProperties.PASSWORD : null,
-                host, port);
-        };
+        MapPropertySource propertySource = new MapPropertySource("embeddedSchemaRegistryInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 }

--- a/embedded-keycloak/src/main/java/com/playtika/testcontainer/keycloak/EmbeddedKeycloakBootstrapConfiguration.java
+++ b/embedded-keycloak/src/main/java/com/playtika/testcontainer/keycloak/EmbeddedKeycloakBootstrapConfiguration.java
@@ -14,11 +14,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.io.ResourceLoader;
-import org.springframework.test.context.DynamicPropertyRegistrar;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -40,19 +42,16 @@ public class EmbeddedKeycloakBootstrapConfiguration {
     @ConditionalOnToxiProxyEnabled(module = "keycloak")
     ToxiproxyClientProxy keycloakContainerProxy(ToxiproxyClient toxiproxyClient,
                                                  ToxiproxyContainer toxiproxyContainer,
-                                                 @Qualifier(BEAN_NAME_EMBEDDED_KEYCLOAK) KeycloakContainer keycloakContainer) {
-        return ToxiproxyHelper.createProxy(
+                                                 @Qualifier(BEAN_NAME_EMBEDDED_KEYCLOAK) KeycloakContainer keycloakContainer,
+                                                 ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 keycloakContainer,
                 keycloakContainer.getHttpPort(),
                 "keycloak");
-    }
-
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "keycloak")
-    public DynamicPropertyRegistrar keycloakToxiProxyDynamicPropertyRegistrar(@Qualifier("keycloakContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.keycloak");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.keycloak", "embeddedKeycloakToxiProxyInfo", environment);
+        return proxy;
     }
 
     /**
@@ -64,24 +63,29 @@ public class EmbeddedKeycloakBootstrapConfiguration {
      * @return The created {@link KeycloakContainer} instance to be registered as bean
      */
     @Bean(name = BEAN_NAME_EMBEDDED_KEYCLOAK, destroyMethod = "stop")
-    public KeycloakContainer keycloak(KeycloakProperties properties, ResourceLoader resourceLoader, Optional<Network> network) {
+    public KeycloakContainer keycloak(ConfigurableEnvironment environment,
+                                      KeycloakProperties properties,
+                                      ResourceLoader resourceLoader,
+                                      Optional<Network> network) {
         KeycloakContainer keycloak = new KeycloakContainer(properties, resourceLoader)
                 .withNetworkAliases(KEYCLOAK_NETWORK_ALIAS);
         network.ifPresent(keycloak::withNetwork);
-        return (KeycloakContainer) configureCommonsAndStart(keycloak, properties, log);
+        keycloak = (KeycloakContainer) configureCommonsAndStart(keycloak, properties, log);
+        registerKeycloakEnvironment(keycloak, environment);
+        return keycloak;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar keycloakDynamicPropertyRegistrar(
-            @Qualifier(BEAN_NAME_EMBEDDED_KEYCLOAK) KeycloakContainer keycloak,
-            KeycloakProperties properties) {
-        return registry -> {
-            registry.add("embedded.keycloak.host", keycloak::getHost);
-            registry.add("embedded.keycloak.http-port", keycloak::getHttpPort);
-            registry.add("embedded.keycloak.auth-server-url", keycloak::getAuthServerUrl);
-            registry.add("embedded.keycloak.port", () -> keycloak.getMappedPort(KEYCLOAK_DEFAULT_HTTP_PORT_INTERNAL));
-            registry.add("embedded.keycloak.networkAlias", () -> KEYCLOAK_NETWORK_ALIAS);
-            registry.add("embedded.keycloak.internalPort", () -> KEYCLOAK_DEFAULT_HTTP_PORT_INTERNAL);
-        };
+    private void registerKeycloakEnvironment(KeycloakContainer keycloak,
+                                             ConfigurableEnvironment environment) {
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.keycloak.host", keycloak.getHost());
+        map.put("embedded.keycloak.http-port", keycloak.getHttpPort());
+        map.put("embedded.keycloak.auth-server-url", keycloak.getAuthServerUrl());
+        map.put("embedded.keycloak.port", keycloak.getMappedPort(KEYCLOAK_DEFAULT_HTTP_PORT_INTERNAL));
+        map.put("embedded.keycloak.networkAlias", KEYCLOAK_NETWORK_ALIAS);
+        map.put("embedded.keycloak.internalPort", KEYCLOAK_DEFAULT_HTTP_PORT_INTERNAL);
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedKeycloakInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 }

--- a/embedded-keydb/src/main/java/com/playtika/testcontainer/keydb/EmbeddedKeyDbBootstrapConfiguration.java
+++ b/embedded-keydb/src/main/java/com/playtika/testcontainer/keydb/EmbeddedKeyDbBootstrapConfiguration.java
@@ -19,8 +19,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.io.ResourceLoader;
-import org.springframework.test.context.DynamicPropertyRegistrar;
 import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -30,6 +31,7 @@ import org.testcontainers.utility.MountableFile;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -69,24 +71,23 @@ public class EmbeddedKeyDbBootstrapConfiguration {
   ToxiproxyClientProxy keydbContainerProxy(ToxiproxyClient toxiproxyClient,
                                             ToxiproxyContainer toxiproxyContainer,
                                             @Qualifier(BEAN_NAME_EMBEDDED_KEYDB) GenericContainer<?> keydb,
-                                            KeyDbProperties properties) {
-    return ToxiproxyHelper.createProxy(
+                                            KeyDbProperties properties,
+                                            ConfigurableEnvironment environment) {
+    ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
             toxiproxyClient,
             toxiproxyContainer,
             keydb,
             properties.getPort(),
             "keydb");
-  }
 
-  @Bean
-  @ConditionalOnToxiProxyEnabled(module = "keydb")
-  public DynamicPropertyRegistrar keydbToxiProxyDynamicPropertyRegistrar(
-      @Qualifier("keydbToxiProxy") ToxiproxyClientProxy proxy) {
-    return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.keydb");
+    ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.keydb", "embeddedKeydbToxiProxyInfo", environment);
+
+    return proxy;
   }
 
   @Bean(name = BEAN_NAME_EMBEDDED_KEYDB, destroyMethod = "stop")
   public GenericContainer<?> keydb(@Qualifier(KEYDB_WAIT_STRATEGY_BEAN_NAME) WaitStrategy keydbStartupCheckStrategy,
+                                   ConfigurableEnvironment environment,
                                    Optional<Network> network) throws Exception {
     GenericContainer<?> keydb =
       new FixedHostPortGenericContainer(ContainerUtils.getDockerImageName(properties).asCanonicalNameString())
@@ -101,18 +102,20 @@ public class EmbeddedKeyDbBootstrapConfiguration {
         .withNetworkAliases(KEYDB_NETWORK_ALIAS);
     network.ifPresent(keydb::withNetwork);
     keydb = configureCommonsAndStart(keydb, properties, log);
+    registerKeydbEnvironment(keydb, environment, properties);
     return keydb;
   }
 
-  @Bean
-  public DynamicPropertyRegistrar keydbDynamicPropertyRegistrar(@Qualifier(BEAN_NAME_EMBEDDED_KEYDB) GenericContainer<?> keydb, KeyDbProperties properties) {
-    return registry -> {
-      registry.add("embedded.keydb.port", properties::getPort);
-      registry.add("embedded.keydb.host", keydb::getHost);
-      registry.add("embedded.keydb.password", properties::getPassword);
-      registry.add("embedded.keydb.user", properties::getUser);
-      registry.add("embedded.keydb.networkAlias", () -> KEYDB_NETWORK_ALIAS);
-    };
+  private void registerKeydbEnvironment(GenericContainer<?> keydb, ConfigurableEnvironment environment, KeyDbProperties properties) {
+    LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+    map.put("embedded.keydb.port", properties.getPort());
+    map.put("embedded.keydb.host", keydb.getHost());
+    map.put("embedded.keydb.password", properties.getPassword());
+    map.put("embedded.keydb.user", properties.getUser());
+    map.put("embedded.keydb.networkAlias", KEYDB_NETWORK_ALIAS);
+
+    MapPropertySource propertySource = new MapPropertySource("embeddedKeydbInfo", map);
+    environment.getPropertySources().addFirst(propertySource);
   }
 
   private Path prepareKeyDbConf() throws IOException {

--- a/embedded-localstack/src/main/java/com/playtika/testcontainer/localstack/EmbeddedLocalStackBootstrapConfiguration.java
+++ b/embedded-localstack/src/main/java/com/playtika/testcontainer/localstack/EmbeddedLocalStackBootstrapConfiguration.java
@@ -15,11 +15,12 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -40,13 +41,18 @@ public class EmbeddedLocalStackBootstrapConfiguration {
     ToxiproxyClientProxy localstackContainerProxy(ToxiproxyClient toxiproxyClient,
                                                    ToxiproxyContainer toxiproxyContainer,
                                                    @Qualifier(BEAN_NAME_EMBEDDED_LOCALSTACK) LocalStackContainer localStack,
-                                                   LocalStackProperties properties) {
-        return ToxiproxyHelper.createProxy(
+                                                   LocalStackProperties properties,
+                                                   ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 localStack,
                 properties.getEdgePort(),
                 "localstack");
+
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.localstack", "embeddedLocalstackToxiProxyInfo", environment);
+
+        return proxy;
     }
 
     @ConditionalOnMissingBean(name = BEAN_NAME_EMBEDDED_LOCALSTACK)
@@ -69,37 +75,37 @@ public class EmbeddedLocalStackBootstrapConfiguration {
             localStackContainer.withServices(service);
         }
         localStackContainer = (LocalStackContainer) configureCommonsAndStart(localStackContainer, properties, log);
+        registerLocalstackEnvironment(localStackContainer, environment, properties);
         return localStackContainer;
     }
 
+    private void registerLocalstackEnvironment(LocalStackContainer localStack, ConfigurableEnvironment environment, LocalStackProperties properties) {
+        String host = localStack.getHost();
+        Integer mappedPort = localStack.getMappedPort(properties.getEdgePort());
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.localstack.host", host);
+        map.put("embedded.localstack.port", mappedPort);
+        map.put("embedded.localstack.endpointUrl", localStack.getEndpoint().toString());
+        map.put("embedded.localstack.accessKey", localStack.getAccessKey());
+        map.put("embedded.localstack.secretAccessKey", localStack.getSecretKey());
+        map.put("embedded.localstack.networkAlias", LOCALSTACK_NETWORK_ALIAS);
+        map.put("embedded.localstack.internalPort", properties.getEdgePort());
+        map.put("embedded.localstack.internalEdgePort", properties.getEdgePort());
+        for (LocalStackContainer.Service service : properties.services) {
+            map.put("embedded.localstack." + service, localStack.getEndpointOverride(service));
+            map.put("embedded.localstack." + service + ".port", mappedPort);
+        }
+        setSystemProperties(localStack);
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedLocalstackInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
+    }
 
     private static void setSystemProperties(LocalStackContainer localStack) {
         System.setProperty("aws.endpointUrl", localStack.getEndpoint().toString());
         System.setProperty("aws.accessKeyId", localStack.getAccessKey());
         System.setProperty("aws.secretAccessKey", localStack.getSecretKey());
-    }
-
-    @Bean
-    public DynamicPropertyRegistrar localStackDynamicPropertyRegistrar(
-            @Qualifier(BEAN_NAME_EMBEDDED_LOCALSTACK) LocalStackContainer localStack,
-            LocalStackProperties properties) {
-        return registry -> {
-            String host = localStack.getHost();
-            Integer mappedPort = localStack.getMappedPort(properties.getEdgePort());
-            registry.add("embedded.localstack.host", () -> host);
-            registry.add("embedded.localstack.port", () -> mappedPort);
-            registry.add("embedded.localstack.endpointUrl", () -> localStack.getEndpoint().toString());
-            registry.add("embedded.localstack.accessKey", localStack::getAccessKey);
-            registry.add("embedded.localstack.secretAccessKey", localStack::getSecretKey);
-            registry.add("embedded.localstack.networkAlias", () -> LOCALSTACK_NETWORK_ALIAS);
-            registry.add("embedded.localstack.internalPort", properties::getEdgePort);
-            registry.add("embedded.localstack.internalEdgePort", properties::getEdgePort);
-            for (LocalStackContainer.Service service : properties.services) {
-                registry.add("embedded.localstack." + service, () -> localStack.getEndpointOverride(service));
-                registry.add("embedded.localstack." + service + ".port", () -> mappedPort);
-            }
-            setSystemProperties(localStack);
-        };
     }
 
 }

--- a/embedded-mailhog/src/main/java/com/playtika/testcontainer/mailhog/EmbeddedMailHogBootstrapConfiguration.java
+++ b/embedded-mailhog/src/main/java/com/playtika/testcontainer/mailhog/EmbeddedMailHogBootstrapConfiguration.java
@@ -19,12 +19,14 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -48,18 +50,35 @@ public class EmbeddedMailHogBootstrapConfiguration {
     ToxiproxyClientProxy mailhogSmtpContainerProxy(ToxiproxyClient toxiproxyClient,
                                                     ToxiproxyContainer toxiproxyContainer,
                                                     @Qualifier(BEAN_NAME_EMBEDDED_MAILHOG) GenericContainer<?> mailhogContainer,
-                                                    MailHogProperties properties) {
-        return ToxiproxyHelper.createProxy(
+                                                    MailHogProperties properties,
+                                                    ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 mailhogContainer,
                 properties.getSmtpPort(),
                 "mailhog");
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.mailhog.smtp.toxiproxy.host", proxy.getContainerIpAddress());
+        map.put("embedded.mailhog.smtp.toxiproxy.port", proxy.getProxyPort());
+        map.put("embedded.mailhog.smtp.toxiproxy.proxyName", proxy.getName());
+
+        log.info("Started MailHog ToxiProxy connection details {}", Map.of(
+                "embedded.mailhog.smtp.toxiproxy.host", proxy.getContainerIpAddress(),
+                "embedded.mailhog.smtp.toxiproxy.port", proxy.getProxyPort(),
+                "embedded.mailhog.smtp.toxiproxy.proxyName", proxy.getName()
+        ));
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedMailhogToxiProxyInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
+
+        return proxy;
     }
 
     @ConditionalOnMissingBean(name = BEAN_NAME_EMBEDDED_MAILHOG)
     @Bean(name = BEAN_NAME_EMBEDDED_MAILHOG, destroyMethod = "stop")
-    public GenericContainer<?> mailHog(MailHogProperties properties, Optional<Network> network) {
+    public GenericContainer<?> mailHog(MailHogProperties properties, ConfigurableEnvironment environment, Optional<Network> network) {
         GenericContainer<?> mailHog = new GenericContainer<>(ContainerUtils.getDockerImageName(properties))
                 .withExposedPorts(properties.getSmtpPort(), properties.getHttpPort())
                 .withNetworkAliases(MAILHOG_NETWORK_ALIAS)
@@ -67,50 +86,34 @@ public class EmbeddedMailHogBootstrapConfiguration {
 
         network.ifPresent(mailHog::withNetwork);
 
-        return configureCommonsAndStart(mailHog, properties, log);
+        mailHog = configureCommonsAndStart(mailHog, properties, log);
+        registerMailhogEnvironment(mailHog, environment, properties);
+        return mailHog;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar mailHogDynamicPropertyRegistrar(
-            @Qualifier(BEAN_NAME_EMBEDDED_MAILHOG) GenericContainer<?> mailHog, MailHogProperties properties) {
-        return registry -> {
-            Integer smtpMappedPort = mailHog.getMappedPort(properties.getSmtpPort());
-            Integer httpMappedPort = mailHog.getMappedPort(properties.getHttpPort());
-            String host = mailHog.getHost();
+    private void registerMailhogEnvironment(GenericContainer<?> mailHog, ConfigurableEnvironment environment, MailHogProperties properties) {
+        Integer smtpMappedPort = mailHog.getMappedPort(properties.getSmtpPort());
+        Integer httpMappedPort = mailHog.getMappedPort(properties.getHttpPort());
+        String host = mailHog.getHost();
 
-            registry.add("embedded.mailhog.host", () -> host);
-            registry.add("embedded.mailhog.smtp-port", () -> smtpMappedPort);
-            registry.add("embedded.mailhog.http-port", () -> httpMappedPort);
-            registry.add("embedded.mailhog.networkAlias", () -> MAILHOG_NETWORK_ALIAS);
-            registry.add("embedded.mailhog.internalSmtpPort", () -> properties.getSmtpPort());
-            registry.add("embedded.mailhog.internalHttpPort", () -> properties.getHttpPort());
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.mailhog.host", host);
+        map.put("embedded.mailhog.smtp-port", smtpMappedPort);
+        map.put("embedded.mailhog.http-port", httpMappedPort);
+        map.put("embedded.mailhog.networkAlias", MAILHOG_NETWORK_ALIAS);
+        map.put("embedded.mailhog.internalSmtpPort", properties.getSmtpPort());
+        map.put("embedded.mailhog.internalHttpPort", properties.getHttpPort());
 
-            log.info("Started MailHog. Connection details: {}", Map.of(
-                    "embedded.mailhog.host", host,
-                    "embedded.mailhog.smtp-port", smtpMappedPort,
-                    "embedded.mailhog.http-port", httpMappedPort,
-                    "embedded.mailhog.networkAlias", MAILHOG_NETWORK_ALIAS,
-                    "embedded.mailhog.internalSmtpPort", properties.getSmtpPort(),
-                    "embedded.mailhog.internalHttpPort", properties.getHttpPort()
-            ));
-        };
+        log.info("Started MailHog. Connection details: {}", Map.of(
+                "embedded.mailhog.host", host,
+                "embedded.mailhog.smtp-port", smtpMappedPort,
+                "embedded.mailhog.http-port", httpMappedPort,
+                "embedded.mailhog.networkAlias", MAILHOG_NETWORK_ALIAS,
+                "embedded.mailhog.internalSmtpPort", properties.getSmtpPort(),
+                "embedded.mailhog.internalHttpPort", properties.getHttpPort()
+        ));
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedMailhogInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
-
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "mailhog")
-    public DynamicPropertyRegistrar mailHogToxiProxyDynamicPropertyRegistrar(
-            @Qualifier("mailhogSmtpContainerProxy") ToxiproxyClientProxy proxy) {
-        return registry -> {
-            registry.add("embedded.mailhog.smtp.toxiproxy.host", proxy::getContainerIpAddress);
-            registry.add("embedded.mailhog.smtp.toxiproxy.port", proxy::getProxyPort);
-            registry.add("embedded.mailhog.smtp.toxiproxy.proxyName", proxy::getName);
-
-            log.info("Started MailHog ToxiProxy connection details {}", Map.of(
-                    "embedded.mailhog.smtp.toxiproxy.host", proxy.getContainerIpAddress(),
-                    "embedded.mailhog.smtp.toxiproxy.port", proxy.getProxyPort(),
-                    "embedded.mailhog.smtp.toxiproxy.proxyName", proxy.getName()
-            ));
-        };
-    }
-
 }

--- a/embedded-mariadb/src/main/java/com/playtika/testcontainer/mariadb/EmbeddedMariaDBBootstrapConfiguration.java
+++ b/embedded-mariadb/src/main/java/com/playtika/testcontainer/mariadb/EmbeddedMariaDBBootstrapConfiguration.java
@@ -14,11 +14,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.MariaDBContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -39,17 +41,21 @@ public class EmbeddedMariaDBBootstrapConfiguration {
     ToxiproxyClientProxy mariadbContainerProxy(ToxiproxyClient toxiproxyClient,
                                                 ToxiproxyContainer toxiproxyContainer,
                                                 @Qualifier(BEAN_NAME_EMBEDDED_MARIADB) MariaDBContainer mariadbContainer,
-                                                MariaDBProperties properties) {
-        return ToxiproxyHelper.createProxy(
+                                                MariaDBProperties properties,
+                                                ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 mariadbContainer,
                 properties.getPort(),
                 "mariadb");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.mariadb", "embeddedMariaDBToxiProxyInfo", environment);
+        return proxy;
     }
 
     @Bean(name = BEAN_NAME_EMBEDDED_MARIADB, destroyMethod = "stop")
-    public MariaDBContainer mariadb(MariaDBProperties properties,
+    public MariaDBContainer mariadb(ConfigurableEnvironment environment,
+                                    MariaDBProperties properties,
                                     Optional<Network> network) throws Exception {
         MariaDBContainer mariadb =
                 new MariaDBContainer<>(ContainerUtils.getDockerImageName(properties))
@@ -67,28 +73,23 @@ public class EmbeddedMariaDBBootstrapConfiguration {
 
         network.ifPresent(mariadb::withNetwork);
         mariadb = (MariaDBContainer) configureCommonsAndStart(mariadb, properties, log);
+        registerMariaDBEnvironment(mariadb, environment, properties);
         return mariadb;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar mariadbDynamicPropertyRegistrar(
-            @Qualifier(BEAN_NAME_EMBEDDED_MARIADB) MariaDBContainer mariadb,
-            MariaDBProperties properties) {
-        return registry -> {
-            registry.add("embedded.mariadb.port", () -> mariadb.getMappedPort(properties.getPort()));
-            registry.add("embedded.mariadb.host", mariadb::getHost);
-            registry.add("embedded.mariadb.schema", properties::getDatabase);
-            registry.add("embedded.mariadb.user", properties::getUser);
-            registry.add("embedded.mariadb.password", properties::getPassword);
-            registry.add("embedded.mariadb.networkAlias", () -> MARIADB_NETWORK_ALIAS);
-            registry.add("embedded.mariadb.internalPort", properties::getPort);
-        };
-    }
+    private void registerMariaDBEnvironment(MariaDBContainer mariadb,
+                                            ConfigurableEnvironment environment,
+                                            MariaDBProperties properties) {
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.mariadb.port", mariadb.getMappedPort(properties.getPort()));
+        map.put("embedded.mariadb.host", mariadb.getHost());
+        map.put("embedded.mariadb.schema", properties.getDatabase());
+        map.put("embedded.mariadb.user", properties.getUser());
+        map.put("embedded.mariadb.password", properties.getPassword());
+        map.put("embedded.mariadb.networkAlias", MARIADB_NETWORK_ALIAS);
+        map.put("embedded.mariadb.internalPort", properties.getPort());
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "mariadb")
-    public DynamicPropertyRegistrar mariadbToxiProxyDynamicPropertyRegistrar(
-            @Qualifier("mariadbContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.mariadb");
+        MapPropertySource propertySource = new MapPropertySource("embeddedMariaDBInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 }

--- a/embedded-memsql/src/main/java/com/playtika/testcontainer/memsql/EmbeddedMemSqlBootstrapConfiguration.java
+++ b/embedded-memsql/src/main/java/com/playtika/testcontainer/memsql/EmbeddedMemSqlBootstrapConfiguration.java
@@ -15,12 +15,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.utility.MountableFile;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -47,24 +49,24 @@ public class EmbeddedMemSqlBootstrapConfiguration {
     ToxiproxyClientProxy memsqlContainerProxy(ToxiproxyClient toxiproxyClient,
                                                ToxiproxyContainer toxiproxyContainer,
                                                @Qualifier(BEAN_NAME_EMBEDDED_MEMSQL) GenericContainer<?> memsql,
-                                               MemSqlProperties properties) {
-        return ToxiproxyHelper.createProxy(
+                                               MemSqlProperties properties,
+                                               ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 memsql,
                 properties.getPort(),
                 "memsql");
-    }
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "memsql")
-    public DynamicPropertyRegistrar memsqlToxiProxyDynamicPropertyRegistrar(@Qualifier("memsqlContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.memsql");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.memsql", "embeddedMemsqlToxiProxyInfo", environment);
+
+        return proxy;
     }
 
     @Bean(name = BEAN_NAME_EMBEDDED_MEMSQL, destroyMethod = "stop")
     public GenericContainer<?> memsql(MemSqlProperties properties,
                                       MemSqlStatusCheck memSqlStatusCheck,
+                                      ConfigurableEnvironment environment,
                                       Optional<Network> network) {
         GenericContainer<?> memsql = new GenericContainer<>(ContainerUtils.getDockerImageName(properties))
                 .withEnv("IGNORE_MIN_REQUIREMENTS", "1")
@@ -82,21 +84,24 @@ public class EmbeddedMemSqlBootstrapConfiguration {
         }
         network.ifPresent(memsql::withNetwork);
         memsql = configureCommonsAndStart(memsql, properties, log);
+        registerMemsqlEnvironment(memsql, environment, properties);
         return memsql;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar memsqlDynamicPropertyRegistrar(@Qualifier(BEAN_NAME_EMBEDDED_MEMSQL) GenericContainer<?> memsql, MemSqlProperties properties) {
-        return registry -> {
-            Integer mappedPort = memsql.getMappedPort(properties.port);
-            String host = memsql.getHost();
-            registry.add("embedded.memsql.port", () -> mappedPort);
-            registry.add("embedded.memsql.host", () -> host);
-            registry.add("embedded.memsql.schema", properties::getDatabase);
-            registry.add("embedded.memsql.user", properties::getUser);
-            registry.add("embedded.memsql.password", properties::getPassword);
-            registry.add("embedded.memsql.networkAlias", () -> MEMSQL_NETWORK_ALIAS);
-            registry.add("embedded.memsql.internalPort", properties::getPort);
-        };
+    private void registerMemsqlEnvironment(GenericContainer<?> memsql, ConfigurableEnvironment environment, MemSqlProperties properties) {
+        Integer mappedPort = memsql.getMappedPort(properties.port);
+        String host = memsql.getHost();
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.memsql.port", mappedPort);
+        map.put("embedded.memsql.host", host);
+        map.put("embedded.memsql.schema", properties.getDatabase());
+        map.put("embedded.memsql.user", properties.getUser());
+        map.put("embedded.memsql.password", properties.getPassword());
+        map.put("embedded.memsql.networkAlias", MEMSQL_NETWORK_ALIAS);
+        map.put("embedded.memsql.internalPort", properties.getPort());
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedMemsqlInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 }

--- a/embedded-minio/src/main/java/com/playtika/testcontainer/minio/EmbeddedMinioBootstrapConfiguration.java
+++ b/embedded-minio/src/main/java/com/playtika/testcontainer/minio/EmbeddedMinioBootstrapConfiguration.java
@@ -14,11 +14,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -50,18 +52,24 @@ public class EmbeddedMinioBootstrapConfiguration {
     ToxiproxyClientProxy minioContainerProxy(ToxiproxyClient toxiproxyClient,
                                               ToxiproxyContainer toxiproxyContainer,
                                               @Qualifier(BEAN_NAME_EMBEDDED_MINIO) GenericContainer<?> minio,
-                                              MinioProperties properties) {
-        return ToxiproxyHelper.createProxy(
+                                              MinioProperties properties,
+                                              ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 minio,
                 properties.getPort(),
                 "minio");
+
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.minio", "embeddedMinioToxiProxyInfo", environment);
+
+        return proxy;
     }
 
     @Bean(name = BEAN_NAME_EMBEDDED_MINIO, destroyMethod = "stop")
     public GenericContainer<?> minio(MinioWaitStrategy minioWaitStrategy,
                                      MinioProperties properties,
+                                     ConfigurableEnvironment environment,
                                      Optional<Network> network) {
         GenericContainer<?> minio =
                 new GenericContainer<>(ContainerUtils.getDockerImageName(properties))
@@ -77,31 +85,23 @@ public class EmbeddedMinioBootstrapConfiguration {
 
         network.ifPresent(minio::withNetwork);
         minio = configureCommonsAndStart(minio, properties, log);
+        registerMinioEnvironment(minio, environment, properties);
         return minio;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar minioDynamicPropertyRegistrar(
-            @Qualifier(BEAN_NAME_EMBEDDED_MINIO) GenericContainer<?> minio,
-            MinioProperties properties) {
-        return registry -> {
-            registry.add("embedded.minio.host", minio::getHost);
-            registry.add("embedded.minio.port", () -> minio.getMappedPort(properties.port));
-            registry.add("embedded.minio.consolePort", () -> minio.getMappedPort(properties.consolePort));
-            registry.add("embedded.minio.accessKey", properties::getAccessKey);
-            registry.add("embedded.minio.secretKey", properties::getSecretKey);
-            registry.add("embedded.minio.region", properties::getRegion);
-            registry.add("embedded.minio.networkAlias", () -> MINIO_NETWORK_ALIAS);
-            registry.add("embedded.minio.internalPort", properties::getPort);
-            registry.add("embedded.minio.internalConsolePort", properties::getConsolePort);
-        };
-    }
+    private void registerMinioEnvironment(GenericContainer<?> minio, ConfigurableEnvironment environment, MinioProperties properties) {
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.minio.host", minio.getHost());
+        map.put("embedded.minio.port", minio.getMappedPort(properties.port));
+        map.put("embedded.minio.consolePort", minio.getMappedPort(properties.consolePort));
+        map.put("embedded.minio.accessKey", properties.getAccessKey());
+        map.put("embedded.minio.secretKey", properties.getSecretKey());
+        map.put("embedded.minio.region", properties.getRegion());
+        map.put("embedded.minio.networkAlias", MINIO_NETWORK_ALIAS);
+        map.put("embedded.minio.internalPort", properties.getPort());
+        map.put("embedded.minio.internalConsolePort", properties.getConsolePort());
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "minio")
-    public DynamicPropertyRegistrar minioToxiProxyDynamicPropertyRegistrar(
-            @Qualifier("minioContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.minio");
+        MapPropertySource propertySource = new MapPropertySource("embeddedMinioInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
-
 }

--- a/embedded-mockserver/src/main/java/com/playtika/testcontainer/mockserver/EmbeddedMockServerBootstrapConfiguration.java
+++ b/embedded-mockserver/src/main/java/com/playtika/testcontainer/mockserver/EmbeddedMockServerBootstrapConfiguration.java
@@ -9,10 +9,12 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.MockServerContainer;
 import org.testcontainers.containers.Network;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -29,7 +31,8 @@ public class EmbeddedMockServerBootstrapConfiguration {
     private static final String MOCKSERVER_NETWORK_ALIAS = "mockserver.testcontainer.docker";
 
     @Bean(name = EMBEDDED_MOCK_SERVER, destroyMethod = "stop")
-    public MockServerContainer mockServerContainer(MockServerProperties properties,
+    public MockServerContainer mockServerContainer(ConfigurableEnvironment environment,
+                                                   MockServerProperties properties,
                                                    Optional<Network> network) {
         MockServerContainer mockServerContainer = new MockServerContainer(ContainerUtils.getDockerImageName(properties));
         mockServerContainer
@@ -39,21 +42,26 @@ public class EmbeddedMockServerBootstrapConfiguration {
         network.ifPresent(mockServerContainer::withNetwork);
 
         mockServerContainer = (MockServerContainer) configureCommonsAndStart(mockServerContainer, properties, log);
+        registerMockServerEnvironment(mockServerContainer, environment, properties);
+        return mockServerContainer;
+    }
+
+    private void registerMockServerEnvironment(MockServerContainer mockServerContainer,
+                                               ConfigurableEnvironment environment,
+                                               MockServerProperties properties) {
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.mockserver.host", mockServerContainer.getHost());
+        map.put("embedded.mockserver.port", mockServerContainer.getMappedPort(properties.getPort()));
+        map.put("embedded.mockserver.networkAlias", MOCKSERVER_NETWORK_ALIAS);
+        map.put("embedded.mockserver.internalPort", properties.getPort());
+
         log.info("Started MockServer server. Connection details: host={}, port={}, networkAlias={}, internalPort={}",
                 mockServerContainer.getHost(),
                 mockServerContainer.getMappedPort(properties.getPort()),
                 MOCKSERVER_NETWORK_ALIAS,
                 properties.getPort());
-        return mockServerContainer;
-    }
 
-    @Bean
-    public DynamicPropertyRegistrar mockServerDynamicPropertyRegistrar(MockServerContainer mockServerContainer, MockServerProperties properties) {
-        return registry -> {
-            registry.add("embedded.mockserver.host", mockServerContainer::getHost);
-            registry.add("embedded.mockserver.port", () -> mockServerContainer.getMappedPort(properties.getPort()));
-            registry.add("embedded.mockserver.networkAlias", () -> MOCKSERVER_NETWORK_ALIAS);
-            registry.add("embedded.mockserver.internalPort", properties::getPort);
-        };
+        MapPropertySource propertySource = new MapPropertySource("embeddedMockServerInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 }

--- a/embedded-mongodb/src/main/java/com/playtika/testcontainer/mongodb/EmbeddedMongodbBootstrapConfiguration.java
+++ b/embedded-mongodb/src/main/java/com/playtika/testcontainer/mongodb/EmbeddedMongodbBootstrapConfiguration.java
@@ -14,8 +14,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.test.context.DynamicPropertyRegistrar;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -25,6 +26,7 @@ import org.testcontainers.shaded.org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -48,18 +50,24 @@ public class EmbeddedMongodbBootstrapConfiguration {
     ToxiproxyClientProxy mongodbContainerProxy(ToxiproxyClient toxiproxyClient,
                                                ToxiproxyContainer toxiproxyContainer,
                                                @Qualifier(BEAN_NAME_EMBEDDED_MONGODB) GenericContainer<?> mongodb,
-                                               MongodbProperties properties) {
-        return ToxiproxyHelper.createProxy(
+                                               MongodbProperties properties,
+                                               ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 mongodb,
                 properties.getPort(),
                 "mongodb"
         );
+
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.mongodb", "embeddedMongodbToxiProxyInfo", environment);
+
+        return proxy;
     }
 
     @Bean(value = BEAN_NAME_EMBEDDED_MONGODB, destroyMethod = "stop")
-    public GenericContainer<?> mongodb(MongodbProperties properties,
+    public GenericContainer<?> mongodb(ConfigurableEnvironment environment,
+                                       MongodbProperties properties,
                                        Optional<Network> network) throws IOException, InterruptedException {
 
         GenericContainer<?> mongodb;
@@ -94,32 +102,32 @@ public class EmbeddedMongodbBootstrapConfiguration {
         network.ifPresent(mongodb::withNetwork);
 
         mongodb = configureCommonsAndStart(mongodb, properties, log);
+        registerMongodbEnvironment(mongodb, environment, properties);
         return mongodb;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar mongodbDynamicPropertyRegistrar(
-            @Qualifier(BEAN_NAME_EMBEDDED_MONGODB) GenericContainer<?> mongodb,
-            MongodbProperties properties) {
-        return registry -> {
-            registry.add("embedded.mongodb.port", () -> mongodb.getMappedPort(properties.getPort()));
-            registry.add("embedded.mongodb.host", mongodb::getHost);
-            registry.add("embedded.mongodb.username", properties::getUsername);
-            registry.add("embedded.mongodb.password", properties::getPassword);
-            registry.add("embedded.mongodb.database", properties::getDatabase);
-            registry.add("embedded.mongodb.networkAlias", () -> MONGODB_NETWORK_ALIAS);
-            registry.add("embedded.mongodb.internalPort", properties::getPort);
-            if (StringUtils.isNotBlank(properties.getReplicaSetName())) {
-                registry.add("embedded.mongodb.replica-set-name", properties::getReplicaSetName);
-            }
-        };
-    }
+    private void registerMongodbEnvironment(GenericContainer<?> mongodb, ConfigurableEnvironment environment, MongodbProperties properties) {
+        Integer mappedPort = mongodb.getMappedPort(properties.getPort());
+        String host = mongodb.getHost();
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "mongodb")
-    public DynamicPropertyRegistrar mongodbToxiProxyDynamicPropertyRegistrar(
-            @Qualifier("mongodbContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.mongodb");
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.mongodb.port", mappedPort);
+        map.put("embedded.mongodb.host", host);
+        map.put("embedded.mongodb.username", properties.getUsername());
+        map.put("embedded.mongodb.password", properties.getPassword());
+        map.put("embedded.mongodb.database", properties.getDatabase());
+        map.put("embedded.mongodb.networkAlias", MONGODB_NETWORK_ALIAS);
+        map.put("embedded.mongodb.internalPort", properties.getPort());
+        if (StringUtils.isNotBlank(properties.getReplicaSetName())) {
+            map.put("embedded.mongodb.replica-set-name", properties.getReplicaSetName());
+        }
+
+        log.info("Started mongodb. Connection Details: {}, Connection URI: mongodb://{}:{}/{}{}", map, host, mappedPort, properties.getDatabase(), Optional.ofNullable(
+                properties.getReplicaSetName()).map("?directConnection=true&authSource=admin&rs="::concat).orElse("")
+        );
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedMongoInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 
 }

--- a/embedded-mssqlserver/src/main/java/com/playtika/testcontainer/mssqlserver/EmbeddedMSSQLServerBootstrapConfiguration.java
+++ b/embedded-mssqlserver/src/main/java/com/playtika/testcontainer/mssqlserver/EmbeddedMSSQLServerBootstrapConfiguration.java
@@ -14,7 +14,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.springframework.util.StringUtils;
 import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.containers.Network;
@@ -22,6 +23,7 @@ import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -42,18 +44,21 @@ public class EmbeddedMSSQLServerBootstrapConfiguration {
     @ConditionalOnToxiProxyEnabled(module = "mssqlserver")
     ToxiproxyClientProxy mssqlserverContainerProxy(ToxiproxyClient toxiproxyClient,
                                                     ToxiproxyContainer toxiproxyContainer,
-                                                    @Qualifier(BEAN_NAME_EMBEDDED_MSSQLSERVER) EmbeddedMSSQLServerContainer mssqlserver) {
-
-        return ToxiproxyHelper.createProxy(
+                                                    @Qualifier(BEAN_NAME_EMBEDDED_MSSQLSERVER) EmbeddedMSSQLServerContainer mssqlserver,
+                                                    ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 mssqlserver,
                 MSSQLServerContainer.MS_SQL_SERVER_PORT,
                 "mssqlserver");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.mssqlserver", "embeddedMssqlServerToxiProxyInfo", environment);
+        return proxy;
     }
 
     @Bean(name = BEAN_NAME_EMBEDDED_MSSQLSERVER, destroyMethod = "stop")
-    public EmbeddedMSSQLServerContainer mssqlServer(MSSQLServerProperties properties,
+    public EmbeddedMSSQLServerContainer mssqlServer(ConfigurableEnvironment environment,
+                                                    MSSQLServerProperties properties,
                                                     Optional<Network> network) {
         EmbeddedMSSQLServerContainer mssqlServerContainer = new EmbeddedMSSQLServerContainer(ContainerUtils.getDockerImageName(properties))
             .withPassword(properties.getPassword())
@@ -74,37 +79,31 @@ public class EmbeddedMSSQLServerBootstrapConfiguration {
         }
 
         mssqlServerContainer = (EmbeddedMSSQLServerContainer) configureCommonsAndStart(mssqlServerContainer, properties, log);
-
+        registerMssqlServerEnvironment(mssqlServerContainer, environment, properties);
         return mssqlServerContainer;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar mssqlServerDynamicPropertyRegistrar(
-            @Qualifier(BEAN_NAME_EMBEDDED_MSSQLSERVER) EmbeddedMSSQLServerContainer mssqlServerContainer,
-            MSSQLServerProperties properties) {
-        return registry -> {
-            Integer mappedPort = mssqlServerContainer.getMappedPort(MS_SQL_SERVER_PORT);
-            String host = mssqlServerContainer.getHost();
+    private void registerMssqlServerEnvironment(EmbeddedMSSQLServerContainer mssqlServerContainer,
+                                                 ConfigurableEnvironment environment,
+                                                 MSSQLServerProperties properties) {
+        Integer mappedPort = mssqlServerContainer.getMappedPort(MS_SQL_SERVER_PORT);
+        String host = mssqlServerContainer.getHost();
 
-            registry.add("embedded.mssqlserver.port", () -> mappedPort);
-            registry.add("embedded.mssqlserver.host", () -> host);
-            registry.add("embedded.mssqlserver.database", () -> "master");
-            registry.add("embedded.mssqlserver.user", () -> "sa");
-            registry.add("embedded.mssqlserver.password", properties::getPassword);
-            registry.add("embedded.mssqlserver.networkAlias", () -> MSSQLSERVER_NETWORK_ALIAS);
-            registry.add("embedded.mssqlserver.internalPort", () -> MS_SQL_SERVER_PORT);
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.mssqlserver.port", mappedPort);
+        map.put("embedded.mssqlserver.host", host);
+        map.put("embedded.mssqlserver.database", "master");
+        map.put("embedded.mssqlserver.user", "sa");
+        map.put("embedded.mssqlserver.password", properties.getPassword());
+        map.put("embedded.mssqlserver.networkAlias", MSSQLSERVER_NETWORK_ALIAS);
+        map.put("embedded.mssqlserver.internalPort", MS_SQL_SERVER_PORT);
 
-            log.info("""
-                Started mssql server. Connection details: embedded.mssqlserver.user=sa, embedded.mssqlserver.password={}, embedded.mssqlserver.database = master,
-                JDBC connection url: jdbc:sqlserver://{}:{};databaseName={};trustServerCertificate=true""", properties.getPassword(), host, mappedPort, "master");
-        };
-    }
+        log.info("""
+            Started mssql server. Connection details: embedded.mssqlserver.user=sa, embedded.mssqlserver.password={}, embedded.mssqlserver.database = master,
+            JDBC connection url: jdbc:sqlserver://{}:{};databaseName={};trustServerCertificate=true""", properties.getPassword(), host, mappedPort, "master");
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "mssqlserver")
-    public DynamicPropertyRegistrar mssqlServerToxiProxyDynamicPropertyRegistrar(
-            @Qualifier("mssqlServerContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.mssqlserver");
+        MapPropertySource propertySource = new MapPropertySource("embeddedMssqlServerInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 
 }

--- a/embedded-mysql/src/main/java/com/playtika/testcontainer/mysql/EmbeddedMySQLBootstrapConfiguration.java
+++ b/embedded-mysql/src/main/java/com/playtika/testcontainer/mysql/EmbeddedMySQLBootstrapConfiguration.java
@@ -14,11 +14,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -39,17 +41,21 @@ public class EmbeddedMySQLBootstrapConfiguration {
     ToxiproxyClientProxy mysqlContainerProxy(ToxiproxyClient toxiproxyClient,
                                               ToxiproxyContainer toxiproxyContainer,
                                               @Qualifier(BEAN_NAME_EMBEDDED_MYSQL) MySQLContainer mysql,
-                                              MySQLProperties properties) {
-        return ToxiproxyHelper.createProxy(
+                                              MySQLProperties properties,
+                                              ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 mysql,
                 properties.getPort(),
                 "mysql");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.mysql", "embeddedMysqlToxiProxyInfo", environment);
+        return proxy;
     }
 
     @Bean(name = BEAN_NAME_EMBEDDED_MYSQL, destroyMethod = "stop")
-    public MySQLContainer mysql(MySQLProperties properties,
+    public MySQLContainer mysql(ConfigurableEnvironment environment,
+                                MySQLProperties properties,
                                 Optional<Network> network) {
 
         MySQLContainer mysql = new MySQLContainer<>(ContainerUtils.getDockerImageName(properties))
@@ -66,29 +72,24 @@ public class EmbeddedMySQLBootstrapConfiguration {
 
         network.ifPresent(mysql::withNetwork);
         mysql = (MySQLContainer) configureCommonsAndStart(mysql, properties, log);
+        registerMySQLEnvironment(mysql, environment, properties);
         return mysql;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar mysqlDynamicPropertyRegistrar(
-            @Qualifier(BEAN_NAME_EMBEDDED_MYSQL) MySQLContainer mysql,
-            MySQLProperties properties) {
-        return registry -> {
-            registry.add("embedded.mysql.port", () -> mysql.getMappedPort(properties.getPort()));
-            registry.add("embedded.mysql.host", mysql::getHost);
-            registry.add("embedded.mysql.schema", properties::getDatabase);
-            registry.add("embedded.mysql.user", properties::getUser);
-            registry.add("embedded.mysql.password", properties::getPassword);
-            registry.add("embedded.mysql.networkAlias", () -> MYSQL_NETWORK_ALIAS);
-            registry.add("embedded.mysql.internalPort", properties::getPort);
-        };
+    private void registerMySQLEnvironment(MySQLContainer mysql,
+                                          ConfigurableEnvironment environment,
+                                          MySQLProperties properties) {
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.mysql.port", mysql.getMappedPort(properties.getPort()));
+        map.put("embedded.mysql.host", mysql.getHost());
+        map.put("embedded.mysql.schema", properties.getDatabase());
+        map.put("embedded.mysql.user", properties.getUser());
+        map.put("embedded.mysql.password", properties.getPassword());
+        map.put("embedded.mysql.networkAlias", MYSQL_NETWORK_ALIAS);
+        map.put("embedded.mysql.internalPort", properties.getPort());
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedMysqlInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "mysql")
-    public DynamicPropertyRegistrar mysqlToxiProxyDynamicPropertyRegistrar(
-            MySQLProperties properties,
-            @Qualifier("mysqlContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.mysql");
-    }
 }

--- a/embedded-native-kafka/src/main/java/com/playtika/testcontainer/nativekafka/configuration/NativeKafkaContainerConfiguration.java
+++ b/embedded-native-kafka/src/main/java/com/playtika/testcontainer/nativekafka/configuration/NativeKafkaContainerConfiguration.java
@@ -15,7 +15,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -33,6 +34,7 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -59,6 +61,7 @@ public class NativeKafkaContainerConfiguration {
 
     @Bean(name = NATIVE_KAFKA_BEAN_NAME, destroyMethod = "stop")
     public GenericContainer<?> nativeKafka(
+            ConfigurableEnvironment environment,
             NativeKafkaConfigurationProperties nativeKafkaProperties,
             Optional<Network> network) {
 
@@ -76,8 +79,29 @@ public class NativeKafkaContainerConfiguration {
 
         // Configure and start the container using common utilities
         nativeKafka = (KafkaContainer) configureCommonsAndStart(nativeKafka, nativeKafkaProperties, log);
-
+        registerNativeKafkaEnvironment(nativeKafka, environment, nativeKafkaProperties);
         return nativeKafka;
+    }
+
+    private void registerNativeKafkaEnvironment(KafkaContainer nativeKafka,
+                                                ConfigurableEnvironment environment,
+                                                NativeKafkaConfigurationProperties nativeKafkaProperties) {
+        String bootstrapServers = nativeKafka.getBootstrapServers();
+        String host = nativeKafka.getHost();
+        Integer port = nativeKafka.getMappedPort(nativeKafkaProperties.getKafkaPort());
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.kafka.bootstrapServers", bootstrapServers);
+        map.put("embedded.kafka.brokerList", bootstrapServers);
+        map.put("embedded.kafka.networkAlias", NATIVE_KAFKA_HOST_NAME);
+        map.put("embedded.kafka.host", host);
+        map.put("embedded.kafka.port", port);
+
+        log.info("Started native kafka broker. Connection details: bootstrapServers={}, host={}, port={}, networkAlias={}",
+                bootstrapServers, host, port, NATIVE_KAFKA_HOST_NAME);
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedNativeKafkaInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 
     @Bean
@@ -94,51 +118,30 @@ public class NativeKafkaContainerConfiguration {
             ToxiproxyClient toxiproxyClient,
             ToxiproxyContainer toxiproxyContainer,
             @Qualifier(NATIVE_KAFKA_BEAN_NAME) GenericContainer<?> nativeKafka,
-            NativeKafkaConfigurationProperties properties) {
+            NativeKafkaConfigurationProperties properties,
+            ConfigurableEnvironment environment) {
 
-        return ToxiproxyHelper.createProxy(
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 nativeKafka,
                 properties.getKafkaPort(),
                 "native-kafka");
-    }
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "kafka")
-    public DynamicPropertyRegistrar nativeKafkaToxiProxyDynamicPropertyRegistrar(
-            @Qualifier("nativeKafkaContainerProxy") ToxiproxyClientProxy proxy) {
+        String proxyBootstrapServers = String.format("%s:%d",
+                proxy.getContainerIpAddress(), proxy.getProxyPort());
 
-        return registry -> {
-            String proxyBootstrapServers = String.format("%s:%d",
-                    proxy.getContainerIpAddress(), proxy.getProxyPort());
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.kafka.toxiproxy.bootstrapServers", proxyBootstrapServers);
+        map.put("embedded.kafka.toxiproxy.brokerList", proxyBootstrapServers);
+        map.put("embedded.kafka.toxiproxy.host", proxy.getContainerIpAddress());
+        map.put("embedded.kafka.toxiproxy.port", proxy.getProxyPort());
+        map.put("embedded.kafka.toxiproxy.proxyName", proxy.getName());
 
-            registry.add("embedded.kafka.toxiproxy.bootstrapServers", () -> proxyBootstrapServers);
-            registry.add("embedded.kafka.toxiproxy.brokerList", () -> proxyBootstrapServers);
-            registry.add("embedded.kafka.toxiproxy.host", proxy::getContainerIpAddress);
-            registry.add("embedded.kafka.toxiproxy.port", proxy::getProxyPort);
-            registry.add("embedded.kafka.toxiproxy.proxyName", proxy::getName);
-        };
-    }
+        MapPropertySource propertySource = new MapPropertySource("embeddedNativeKafkaToxiProxyInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
 
-    @Bean
-    public DynamicPropertyRegistrar nativeKafkaDynamicPropertyRegistrar(
-            @Qualifier(NATIVE_KAFKA_BEAN_NAME) GenericContainer<?> nativeKafka,
-            NativeKafkaConfigurationProperties nativeKafkaProperties) {
-        return registry -> {
-            String bootstrapServers = ((KafkaContainer) nativeKafka).getBootstrapServers();
-            String host = nativeKafka.getHost();
-            Integer port = nativeKafka.getMappedPort(nativeKafkaProperties.getKafkaPort());
-
-            registry.add("embedded.kafka.bootstrapServers", () -> bootstrapServers);
-            registry.add("embedded.kafka.brokerList", () -> bootstrapServers);
-            registry.add("embedded.kafka.networkAlias", () -> NATIVE_KAFKA_HOST_NAME);
-            registry.add("embedded.kafka.host", () -> host);
-            registry.add("embedded.kafka.port", () -> port);
-
-            log.info("Started native kafka broker. Connection details: bootstrapServers={}, host={}, port={}, networkAlias={}",
-                    bootstrapServers, host, port, NATIVE_KAFKA_HOST_NAME);
-        };
+        return proxy;
     }
 
     private void configureFileSystemBind(NativeKafkaConfigurationProperties nativeKafkaProperties, KafkaContainer nativeKafka) {

--- a/embedded-native-kafka/src/test/java/com/playtika/testcontainer/nativekafka/configuration/NativeKafkaContainerConfigurationTest.java
+++ b/embedded-native-kafka/src/test/java/com/playtika/testcontainer/nativekafka/configuration/NativeKafkaContainerConfigurationTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.mock.env.MockEnvironment;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.kafka.KafkaContainer;
@@ -41,6 +43,8 @@ class NativeKafkaContainerConfigurationTest {
 
     @Mock
     private GenericContainer<?> genericContainer;
+
+    private ConfigurableEnvironment environment = new MockEnvironment();
 
     @TempDir
     private Path tempDir;
@@ -73,7 +77,7 @@ class NativeKafkaContainerConfigurationTest {
             containerUtilsMock.when(() -> configureCommonsAndStart(any(KafkaContainer.class), any(CommonContainerProperties.class), any()))
                     .thenReturn(kafkaContainer);
 
-            GenericContainer<?> result = configuration.nativeKafka(properties, Optional.of(network));
+            GenericContainer<?> result = configuration.nativeKafka(environment, properties, Optional.of(network));
 
             assertThat(result).isEqualTo(kafkaContainer);
             containerUtilsMock.verify(() -> configureCommonsAndStart(any(KafkaContainer.class), any(CommonContainerProperties.class), any()));
@@ -95,7 +99,7 @@ class NativeKafkaContainerConfigurationTest {
             containerUtilsMock.when(() -> configureCommonsAndStart(any(KafkaContainer.class), any(CommonContainerProperties.class), any()))
                     .thenReturn(kafkaContainer);
 
-            GenericContainer<?> result = configuration.nativeKafka(properties, Optional.of(network));
+            GenericContainer<?> result = configuration.nativeKafka(environment, properties, Optional.of(network));
 
             assertThat(result).isEqualTo(kafkaContainer);
 
@@ -119,7 +123,7 @@ class NativeKafkaContainerConfigurationTest {
             containerUtilsMock.when(() -> configureCommonsAndStart(any(KafkaContainer.class), any(CommonContainerProperties.class), any()))
                     .thenReturn(kafkaContainer);
 
-            GenericContainer<?> result = configuration.nativeKafka(properties, Optional.of(network));
+            GenericContainer<?> result = configuration.nativeKafka(environment, properties, Optional.of(network));
 
             assertThat(result).isEqualTo(kafkaContainer);
             assertThat(Files.exists(tempDir.resolve("embedded-native-kafka-data"))).isFalse();
@@ -138,7 +142,7 @@ class NativeKafkaContainerConfigurationTest {
             containerUtilsMock.when(() -> configureCommonsAndStart(any(KafkaContainer.class), any(CommonContainerProperties.class), any()))
                     .thenReturn(kafkaContainer);
 
-            configuration.nativeKafka(properties, Optional.of(network));
+            configuration.nativeKafka(environment, properties, Optional.of(network));
         }
     }
 
@@ -169,7 +173,7 @@ class NativeKafkaContainerConfigurationTest {
             containerUtilsMock.when(() -> configureCommonsAndStart(any(KafkaContainer.class), any(CommonContainerProperties.class), any()))
                     .thenReturn(kafkaContainer);
 
-            configuration.nativeKafka(properties, Optional.of(network));
+            configuration.nativeKafka(environment, properties, Optional.of(network));
 
             assertThat(Files.exists(testPath)).isTrue();
             assertThat(Files.isDirectory(testPath)).isTrue();
@@ -195,7 +199,7 @@ class NativeKafkaContainerConfigurationTest {
             containerUtilsMock.when(() -> configureCommonsAndStart(any(KafkaContainer.class), any(CommonContainerProperties.class), any()))
                     .thenReturn(kafkaContainer);
 
-            configuration.nativeKafka(properties, Optional.of(network));
+            configuration.nativeKafka(environment, properties, Optional.of(network));
 
             assertThat(Files.exists(parentPath)).isTrue();
             assertThat(Files.exists(testPath)).isTrue();
@@ -227,7 +231,7 @@ class NativeKafkaContainerConfigurationTest {
             containerUtilsMock.when(() -> configureCommonsAndStart(any(KafkaContainer.class), any(CommonContainerProperties.class), any()))
                     .thenReturn(kafkaContainer);
 
-            configuration.nativeKafka(properties, Optional.of(network));
+            configuration.nativeKafka(environment, properties, Optional.of(network));
 
             assertThat(Files.exists(existingPath)).isTrue();
         }

--- a/embedded-nats/src/main/java/com/playtika/testcontainer/nats/EmbeddedNatsBootstrapConfiguration.java
+++ b/embedded-nats/src/main/java/com/playtika/testcontainer/nats/EmbeddedNatsBootstrapConfiguration.java
@@ -15,7 +15,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
@@ -24,6 +25,7 @@ import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
 import org.testcontainers.utility.MountableFile;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -45,23 +47,21 @@ public class EmbeddedNatsBootstrapConfiguration {
     ToxiproxyClientProxy natsContainerProxy(ToxiproxyClient toxiproxyClient,
                                              ToxiproxyContainer toxiproxyContainer,
                                              @Qualifier(BEAN_NAME_EMBEDDED_NATS) GenericContainer<?> natsContainer,
-                                             NatsProperties properties) {
-        return ToxiproxyHelper.createProxy(
+                                             NatsProperties properties,
+                                             ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 natsContainer,
                 properties.getClientPort(),
                 "nats");
-    }
-
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "nats")
-    public DynamicPropertyRegistrar natsToxiProxyDynamicPropertyRegistrar(@Qualifier(BEAN_NAME_EMBEDDED_NATS_TOXI_PROXY) ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.nats");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.nats", "embeddedNatsToxiProxyInfo", environment);
+        return proxy;
     }
 
     @Bean(name = BEAN_NAME_EMBEDDED_NATS, destroyMethod = "stop")
-    public GenericContainer<?> natsContainer(NatsProperties properties,
+    public GenericContainer<?> natsContainer(ConfigurableEnvironment environment,
+                                             NatsProperties properties,
                                              Optional<Network> network) {
         WaitStrategy waitStrategy = new WaitAllStrategy()
                 .withStrategy(new HostPortWaitStrategy())
@@ -76,27 +76,32 @@ public class EmbeddedNatsBootstrapConfiguration {
         network.ifPresent(natsContainer::withNetwork);
 
         natsContainer = configureCommonsAndStart(natsContainer, properties, log);
+        registerNatsEnvironment(natsContainer, environment, properties);
+        return natsContainer;
+    }
 
+    private void registerNatsEnvironment(GenericContainer<?> natsContainer,
+                                         ConfigurableEnvironment environment,
+                                         NatsProperties properties) {
         Integer clientMappedPort = natsContainer.getMappedPort(properties.getClientPort());
         Integer httpMonitorMappedPort = natsContainer.getMappedPort(properties.getHttpMonitorPort());
         Integer routeConnectionsMappedPort = natsContainer.getMappedPort(properties.getRouteConnectionsPort());
         String host = natsContainer.getHost();
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.nats.host", host);
+        map.put("embedded.nats.port", clientMappedPort);
+        map.put("embedded.nats.httpMonitorPort", httpMonitorMappedPort);
+        map.put("embedded.nats.routeConnectionsPort", routeConnectionsMappedPort);
+        map.put("embedded.nats.networkAlias", NATS_NETWORK_ALIAS);
+        map.put("embedded.nats.internalClientPort", properties.getClientPort());
+        map.put("embedded.nats.internalHttpMonitorPort", properties.getHttpMonitorPort());
+        map.put("embedded.nats.internalRouteConnectionsPort", properties.getRouteConnectionsPort());
+
         log.info("Started NATS server. Connection details host={}, port={}, httpMonitorPort={}, routeConnectionsPort={}, networkAlias={}, internalClientPort={}, internalHttpMonitorPort={}, internalRouteConnectionsPort={}",
                 host, clientMappedPort, httpMonitorMappedPort, routeConnectionsMappedPort, NATS_NETWORK_ALIAS, properties.getClientPort(), properties.getHttpMonitorPort(), properties.getRouteConnectionsPort());
-        return natsContainer;
-    }
 
-    @Bean
-    public DynamicPropertyRegistrar natsDynamicPropertyRegistrar(@Qualifier(BEAN_NAME_EMBEDDED_NATS) GenericContainer<?> natsContainer, NatsProperties properties) {
-        return registry -> {
-            registry.add("embedded.nats.host", natsContainer::getHost);
-            registry.add("embedded.nats.port", () -> natsContainer.getMappedPort(properties.getClientPort()));
-            registry.add("embedded.nats.httpMonitorPort", () -> natsContainer.getMappedPort(properties.getHttpMonitorPort()));
-            registry.add("embedded.nats.routeConnectionsPort", () -> natsContainer.getMappedPort(properties.getRouteConnectionsPort()));
-            registry.add("embedded.nats.networkAlias", () -> NATS_NETWORK_ALIAS);
-            registry.add("embedded.nats.internalClientPort", properties::getClientPort);
-            registry.add("embedded.nats.internalHttpMonitorPort", properties::getHttpMonitorPort);
-            registry.add("embedded.nats.internalRouteConnectionsPort", properties::getRouteConnectionsPort);
-        };
+        MapPropertySource propertySource = new MapPropertySource("embeddedNatsInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 }

--- a/embedded-neo4j/src/main/java/com/playtika/testcontainer/neo4j/EmbeddedNeo4jBootstrapConfiguration.java
+++ b/embedded-neo4j/src/main/java/com/playtika/testcontainer/neo4j/EmbeddedNeo4jBootstrapConfiguration.java
@@ -14,11 +14,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.Neo4jContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -39,49 +41,53 @@ public class EmbeddedNeo4jBootstrapConfiguration {
     ToxiproxyClientProxy neo4jContainerProxy(ToxiproxyClient toxiproxyClient,
                                               ToxiproxyContainer toxiproxyContainer,
                                               @Qualifier(BEAN_NAME_EMBEDDED_NEO4J) Neo4jContainer neo4j,
-                                              Neo4jProperties properties) {
-        return ToxiproxyHelper.createProxy(
+                                              Neo4jProperties properties,
+                                              ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 neo4j,
                 properties.getBoltPort(),
                 "neo4j");
-    }
-
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "neo4j")
-    public DynamicPropertyRegistrar neo4jToxiProxyDynamicPropertyRegistrar(@Qualifier("neo4jContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.neo4j");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.neo4j", "embeddedNeo4jToxiProxyInfo", environment);
+        return proxy;
     }
 
     @Bean(name = BEAN_NAME_EMBEDDED_NEO4J, destroyMethod = "stop")
-    public Neo4jContainer neo4j(Neo4jProperties properties, Optional<Network> network) {
+    public Neo4jContainer neo4j(ConfigurableEnvironment environment,
+                                Neo4jProperties properties,
+                                Optional<Network> network) {
         Neo4jContainer neo4j = new Neo4jContainer<>(ContainerUtils.getDockerImageName(properties))
                 .withAdminPassword(properties.password)
                 .withNetworkAliases(NEO4J_NETWORK_ALIAS);
 
         network.ifPresent(neo4j::withNetwork);
         neo4j = (Neo4jContainer) configureCommonsAndStart(neo4j, properties, log);
+        registerNeo4jEnvironment(neo4j, environment, properties);
         return neo4j;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar neo4jDynamicPropertyRegistrar(@Qualifier(BEAN_NAME_EMBEDDED_NEO4J) Neo4jContainer neo4j, Neo4jProperties properties) {
-        return registry -> {
-            Integer httpsPort = neo4j.getMappedPort(properties.httpsPort);
-            Integer httpPort = neo4j.getMappedPort(properties.httpPort);
-            Integer boltPort = neo4j.getMappedPort(properties.boltPort);
-            String host = neo4j.getHost();
-            registry.add("embedded.neo4j.httpsPort", () -> httpsPort);
-            registry.add("embedded.neo4j.httpPort", () -> httpPort);
-            registry.add("embedded.neo4j.boltPort", () -> boltPort);
-            registry.add("embedded.neo4j.host", () -> host);
-            registry.add("embedded.neo4j.password", properties::getPassword);
-            registry.add("embedded.neo4j.user", properties::getUser);
-            registry.add("embedded.neo4j.networkAlias", () -> NEO4J_NETWORK_ALIAS);
-            registry.add("embedded.neo4j.internalHttpsPort", properties::getHttpsPort);
-            registry.add("embedded.neo4j.internalHttpPort", properties::getHttpPort);
-            registry.add("embedded.neo4j.internalBoltPort", properties::getBoltPort);
-        };
+    private void registerNeo4jEnvironment(Neo4jContainer neo4j,
+                                          ConfigurableEnvironment environment,
+                                          Neo4jProperties properties) {
+        Integer httpsPort = neo4j.getMappedPort(properties.httpsPort);
+        Integer httpPort = neo4j.getMappedPort(properties.httpPort);
+        Integer boltPort = neo4j.getMappedPort(properties.boltPort);
+        String host = neo4j.getHost();
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.neo4j.httpsPort", httpsPort);
+        map.put("embedded.neo4j.httpPort", httpPort);
+        map.put("embedded.neo4j.boltPort", boltPort);
+        map.put("embedded.neo4j.host", host);
+        map.put("embedded.neo4j.password", properties.getPassword());
+        map.put("embedded.neo4j.user", properties.getUser());
+        map.put("embedded.neo4j.networkAlias", NEO4J_NETWORK_ALIAS);
+        map.put("embedded.neo4j.internalHttpsPort", properties.getHttpsPort());
+        map.put("embedded.neo4j.internalHttpPort", properties.getHttpPort());
+        map.put("embedded.neo4j.internalBoltPort", properties.getBoltPort());
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedNeo4jInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 }

--- a/embedded-opensearch/src/main/java/com/playtika/testcontainer/opensearch/EmbeddedOpenSearchBootstrapConfiguration.java
+++ b/embedded-opensearch/src/main/java/com/playtika/testcontainer/opensearch/EmbeddedOpenSearchBootstrapConfiguration.java
@@ -15,11 +15,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -51,30 +53,37 @@ public class EmbeddedOpenSearchBootstrapConfiguration {
 
     @ConditionalOnMissingBean(name = BEAN_NAME_EMBEDDED_OPEN_SEARCH)
     @Bean(name = BEAN_NAME_EMBEDDED_OPEN_SEARCH, destroyMethod = "stop")
-    public GenericContainer openSearch(OpenSearchProperties properties,
+    public GenericContainer openSearch(ConfigurableEnvironment environment,
+                                       OpenSearchProperties properties,
                                        Optional<Network> network) {
         GenericContainer openSearch = OpenSearchContainerFactory.create(properties)
                 .withNetworkAliases(OPENSEARCH_NETWORK_ALIAS);
         network.ifPresent(openSearch::withNetwork);
         openSearch = configureCommonsAndStart(openSearch, properties, log);
-        Integer httpPort = openSearch.getMappedPort(properties.getHttpPort());
-        Integer transportPort = openSearch.getMappedPort(properties.getTransportPort());
-        String host = openSearch.getHost();
-        log.info("Started OpenSearch server. Connection details: clusterName={}, host={}, httpPort={}, transportPort={}, networkAlias={}, internalHttpPort={}, internalTransportPort={}",
-                properties.getClusterName(), host, httpPort, transportPort, OPENSEARCH_NETWORK_ALIAS, properties.getHttpPort(), properties.getTransportPort());
+        registerOpenSearchEnvironment(openSearch, environment, properties);
         return openSearch;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar opensearchDynamicPropertyRegistrar(@Qualifier(BEAN_NAME_EMBEDDED_OPEN_SEARCH) GenericContainer<?> openSearch, OpenSearchProperties properties) {
-        return registry -> {
-            registry.add("embedded.opensearch.clusterName", properties::getClusterName);
-            registry.add("embedded.opensearch.host", openSearch::getHost);
-            registry.add("embedded.opensearch.httpPort", () -> openSearch.getMappedPort(properties.getHttpPort()));
-            registry.add("embedded.opensearch.transportPort", () -> openSearch.getMappedPort(properties.getTransportPort()));
-            registry.add("embedded.opensearch.networkAlias", () -> OPENSEARCH_NETWORK_ALIAS);
-            registry.add("embedded.opensearch.internalHttpPort", properties::getHttpPort);
-            registry.add("embedded.opensearch.internalTransportPort", properties::getTransportPort);
-        };
+    private void registerOpenSearchEnvironment(GenericContainer<?> openSearch,
+                                               ConfigurableEnvironment environment,
+                                               OpenSearchProperties properties) {
+        Integer httpPort = openSearch.getMappedPort(properties.getHttpPort());
+        Integer transportPort = openSearch.getMappedPort(properties.getTransportPort());
+        String host = openSearch.getHost();
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.opensearch.clusterName", properties.getClusterName());
+        map.put("embedded.opensearch.host", host);
+        map.put("embedded.opensearch.httpPort", httpPort);
+        map.put("embedded.opensearch.transportPort", transportPort);
+        map.put("embedded.opensearch.networkAlias", OPENSEARCH_NETWORK_ALIAS);
+        map.put("embedded.opensearch.internalHttpPort", properties.getHttpPort());
+        map.put("embedded.opensearch.internalTransportPort", properties.getTransportPort());
+
+        log.info("Started OpenSearch server. Connection details: clusterName={}, host={}, httpPort={}, transportPort={}, networkAlias={}, internalHttpPort={}, internalTransportPort={}",
+                properties.getClusterName(), host, httpPort, transportPort, OPENSEARCH_NETWORK_ALIAS, properties.getHttpPort(), properties.getTransportPort());
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedOpensearchInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 }

--- a/embedded-oracle-xe/src/main/java/com/playtika/testcontainer/oracle/EmbeddedOracleBootstrapConfiguration.java
+++ b/embedded-oracle-xe/src/main/java/com/playtika/testcontainer/oracle/EmbeddedOracleBootstrapConfiguration.java
@@ -14,11 +14,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.OracleContainer;
 import org.testcontainers.containers.ToxiproxyContainer;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -39,23 +41,22 @@ public class EmbeddedOracleBootstrapConfiguration {
     @ConditionalOnToxiProxyEnabled(module = "oracle")
     ToxiproxyClientProxy oracleContainerProxy(ToxiproxyClient toxiproxyClient,
                                                ToxiproxyContainer toxiproxyContainer,
-                                               @Qualifier(BEAN_NAME_EMBEDDED_ORACLE) OracleContainer oracle) {
-        return ToxiproxyHelper.createProxy(
+                                               @Qualifier(BEAN_NAME_EMBEDDED_ORACLE) OracleContainer oracle,
+                                               ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 oracle,
                 ORACLE_PORT,
                 "oracle");
-    }
-
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "oracle")
-    public DynamicPropertyRegistrar oracleToxiProxyDynamicPropertyRegistrar(@Qualifier("oracleContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.oracle");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.oracle", "embeddedOracleToxiProxyInfo", environment);
+        return proxy;
     }
 
     @Bean(name = BEAN_NAME_EMBEDDED_ORACLE, destroyMethod = "stop")
-    public OracleContainer oracle(OracleProperties properties, Optional<Network> network) {
+    public OracleContainer oracle(ConfigurableEnvironment environment,
+                                  OracleProperties properties,
+                                  Optional<Network> network) {
         OracleContainer oracle =
                 new OracleContainer(ContainerUtils.getDockerImageName(properties))
                         .withUsername(properties.getUser())
@@ -65,21 +66,27 @@ public class EmbeddedOracleBootstrapConfiguration {
 
         network.ifPresent(oracle::withNetwork);
         oracle = (OracleContainer) configureCommonsAndStart(oracle, properties, log);
+        registerOracleEnvironment(oracle, environment, properties);
         return oracle;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar oracleDynamicPropertyRegistrar(@Qualifier(BEAN_NAME_EMBEDDED_ORACLE) OracleContainer oracle, OracleProperties properties) {
-        return registry -> {
-            Integer mappedPort = oracle.getMappedPort(ORACLE_PORT);
-            String host = oracle.getHost();
-            registry.add("embedded.oracle.port", () -> mappedPort);
-            registry.add("embedded.oracle.host", () -> host);
-            registry.add("embedded.oracle.database", properties::getDatabase);
-            registry.add("embedded.oracle.user", properties::getUser);
-            registry.add("embedded.oracle.password", properties::getPassword);
-            registry.add("embedded.oracle.networkAlias", () -> ORACLE_NETWORK_ALIAS);
-            registry.add("embedded.oracle.internalPort", () -> ORACLE_PORT);
-        };
+    private void registerOracleEnvironment(OracleContainer oracle,
+                                           ConfigurableEnvironment environment,
+                                           OracleProperties properties) {
+        Integer mappedPort = oracle.getMappedPort(ORACLE_PORT);
+        String host = oracle.getHost();
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.oracle.port", mappedPort);
+        map.put("embedded.oracle.host", host);
+        map.put("embedded.oracle.database", properties.getDatabase());
+        map.put("embedded.oracle.user", properties.getUser());
+        map.put("embedded.oracle.password", properties.getPassword());
+        map.put("embedded.oracle.networkAlias", ORACLE_NETWORK_ALIAS);
+        map.put("embedded.oracle.internalPort", ORACLE_PORT);
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedOracleInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
+
 }

--- a/embedded-postgresql/src/main/java/com/playtika/testcontainer/postgresql/EmbeddedPostgreSQLBootstrapConfiguration.java
+++ b/embedded-postgresql/src/main/java/com/playtika/testcontainer/postgresql/EmbeddedPostgreSQLBootstrapConfiguration.java
@@ -14,7 +14,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.springframework.util.StringUtils;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -22,6 +23,7 @@ import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -41,23 +43,21 @@ public class EmbeddedPostgreSQLBootstrapConfiguration {
     @ConditionalOnToxiProxyEnabled(module = "postgresql")
     ToxiproxyClientProxy postgresqlContainerProxy(ToxiproxyClient toxiproxyClient,
                                                    ToxiproxyContainer toxiproxyContainer,
-                                                   @Qualifier(BEAN_NAME_EMBEDDED_POSTGRESQL) PostgreSQLContainer postgresql) {
-        return ToxiproxyHelper.createProxy(
+                                                   @Qualifier(BEAN_NAME_EMBEDDED_POSTGRESQL) PostgreSQLContainer postgresql,
+                                                   ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 postgresql,
                 PostgreSQLContainer.POSTGRESQL_PORT,
                 "postgresql");
-    }
-
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "postgresql")
-    public DynamicPropertyRegistrar postgresqlToxiProxyDynamicPropertyRegistrar(@Qualifier("postgresqlContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.postgresql");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.postgresql", "embeddedPostgreSQLToxiProxyInfo", environment);
+        return proxy;
     }
 
     @Bean(name = BEAN_NAME_EMBEDDED_POSTGRESQL, destroyMethod = "stop")
-    public PostgreSQLContainer postgresql(PostgreSQLProperties properties,
+    public PostgreSQLContainer postgresql(ConfigurableEnvironment environment,
+                                          PostgreSQLProperties properties,
                                           Optional<Network> network) {
         PostgreSQLContainer postgresql =
                 new PostgreSQLContainer<>(ContainerUtils.getDockerImageName(properties))
@@ -74,25 +74,31 @@ public class EmbeddedPostgreSQLBootstrapConfiguration {
             postgresql.waitingFor(waitStrategy);
         }
         postgresql = (PostgreSQLContainer) configureCommonsAndStart(postgresql, properties, log);
-        Integer mappedPort = postgresql.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT);
-        String host = postgresql.getHost();
-        String jdbcURL = "jdbc:postgresql://" + host + ":" + mappedPort + "/" + properties.getDatabase();
-        log.info("Started postgresql server. Connection details: host={}, port={}, schema={}, user={}, password={}, networkAlias={}, internalPort={}, JDBC connection url: {}",
-                host, mappedPort, properties.getDatabase(), properties.getUser(), properties.getPassword(), POSTGRESQL_NETWORK_ALIAS, PostgreSQLContainer.POSTGRESQL_PORT, jdbcURL);
+        registerPostgreSQLEnvironment(postgresql, environment, properties);
         return postgresql;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar postgresqlDynamicPropertyRegistrar(@Qualifier(BEAN_NAME_EMBEDDED_POSTGRESQL) PostgreSQLContainer postgresql, PostgreSQLProperties properties) {
-        return registry -> {
-            registry.add("embedded.postgresql.port", () -> postgresql.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT));
-            registry.add("embedded.postgresql.host", postgresql::getHost);
-            registry.add("embedded.postgresql.schema", properties::getDatabase);
-            registry.add("embedded.postgresql.user", properties::getUser);
-            registry.add("embedded.postgresql.password", properties::getPassword);
-            registry.add("embedded.postgresql.networkAlias", () -> POSTGRESQL_NETWORK_ALIAS);
-            registry.add("embedded.postgresql.internalPort", () -> PostgreSQLContainer.POSTGRESQL_PORT);
-        };
+    private void registerPostgreSQLEnvironment(PostgreSQLContainer postgresql,
+                                               ConfigurableEnvironment environment,
+                                               PostgreSQLProperties properties) {
+        Integer mappedPort = postgresql.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT);
+        String host = postgresql.getHost();
+        String jdbcURL = "jdbc:postgresql://" + host + ":" + mappedPort + "/" + properties.getDatabase();
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.postgresql.port", mappedPort);
+        map.put("embedded.postgresql.host", host);
+        map.put("embedded.postgresql.schema", properties.getDatabase());
+        map.put("embedded.postgresql.user", properties.getUser());
+        map.put("embedded.postgresql.password", properties.getPassword());
+        map.put("embedded.postgresql.networkAlias", POSTGRESQL_NETWORK_ALIAS);
+        map.put("embedded.postgresql.internalPort", PostgreSQLContainer.POSTGRESQL_PORT);
+
+        log.info("Started postgresql server. Connection details: host={}, port={}, schema={}, user={}, password={}, networkAlias={}, internalPort={}, JDBC connection url: {}",
+                host, mappedPort, properties.getDatabase(), properties.getUser(), properties.getPassword(), POSTGRESQL_NETWORK_ALIAS, PostgreSQLContainer.POSTGRESQL_PORT, jdbcURL);
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedPostgreSQLInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 
 }

--- a/embedded-prometheus/src/main/java/com/playtika/testcontainer/prometheus/EmbeddedPrometheusBootstrapConfiguration.java
+++ b/embedded-prometheus/src/main/java/com/playtika/testcontainer/prometheus/EmbeddedPrometheusBootstrapConfiguration.java
@@ -15,13 +15,15 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -52,23 +54,21 @@ public class EmbeddedPrometheusBootstrapConfiguration {
     ToxiproxyClientProxy prometheusContainerProxy(ToxiproxyClient toxiproxyClient,
                                                    ToxiproxyContainer toxiproxyContainer,
                                                    @Qualifier(PROMETHEUS_BEAN_NAME) GenericContainer<?> prometheus,
-                                                  PrometheusProperties properties) {
-        return ToxiproxyHelper.createProxy(
+                                                  PrometheusProperties properties,
+                                                  ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 prometheus,
                 properties.getPort(),
                 "prometheus");
-    }
-
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "prometheus")
-    public DynamicPropertyRegistrar prometheusToxiProxyDynamicPropertyRegistrar(@Qualifier("prometheusContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.prometheus");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.prometheus", "embeddedPrometheusToxiProxyInfo", environment);
+        return proxy;
     }
 
     @Bean(name = PROMETHEUS_BEAN_NAME, destroyMethod = "stop")
-    public GenericContainer<?> prometheus(PrometheusProperties properties,
+    public GenericContainer<?> prometheus(ConfigurableEnvironment environment,
+                                          PrometheusProperties properties,
                                           WaitStrategy prometheusWaitStrategy,
                                           Optional<Network> network) {
 
@@ -82,20 +82,24 @@ public class EmbeddedPrometheusBootstrapConfiguration {
         network.ifPresent(container::withNetwork);
 
         configureCommonsAndStart(container, properties, log);
-
+        registerPrometheusEnvironment(container, environment, properties);
         return container;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar prometheusDynamicPropertyRegistrar(@Qualifier(PROMETHEUS_BEAN_NAME) GenericContainer<?> prometheus, PrometheusProperties properties) {
-        return registry -> {
-            Integer mappedPort = prometheus.getMappedPort(properties.port);
-            String host = prometheus.getHost();
-            registry.add("embedded.prometheus.host", () -> host);
-            registry.add("embedded.prometheus.port", () -> mappedPort);
-            registry.add("embedded.prometheus.staticNetworkAlias", () -> PROMETHEUS_NETWORK_ALIAS);
-            registry.add("embedded.prometheus.internalPort", properties::getPort);
-        };
+    private void registerPrometheusEnvironment(GenericContainer<?> prometheus,
+                                               ConfigurableEnvironment environment,
+                                               PrometheusProperties properties) {
+        Integer mappedPort = prometheus.getMappedPort(properties.port);
+        String host = prometheus.getHost();
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.prometheus.host", host);
+        map.put("embedded.prometheus.port", mappedPort);
+        map.put("embedded.prometheus.staticNetworkAlias", PROMETHEUS_NETWORK_ALIAS);
+        map.put("embedded.prometheus.internalPort", properties.getPort());
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedPrometheusInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 
 }

--- a/embedded-pulsar/src/main/java/com/playtika/testcontainer/pulsar/EmbeddedPulsarBootstrapConfiguration.java
+++ b/embedded-pulsar/src/main/java/com/playtika/testcontainer/pulsar/EmbeddedPulsarBootstrapConfiguration.java
@@ -13,11 +13,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.PulsarContainer;
 import org.testcontainers.containers.ToxiproxyContainer;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.pulsar.PulsarProperties.EMBEDDED_PULSAR;
@@ -36,17 +38,21 @@ public class EmbeddedPulsarBootstrapConfiguration {
     ToxiproxyClientProxy pulsarContainerProxy(ToxiproxyClient toxiproxyClient,
                                                ToxiproxyContainer toxiproxyContainer,
                                                @Qualifier(EMBEDDED_PULSAR) PulsarContainer embeddedPulsar,
-                                               PulsarProperties pulsarProperties) {
-        return ToxiproxyHelper.createProxy(
+                                               PulsarProperties pulsarProperties,
+                                               ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 embeddedPulsar,
                 pulsarProperties.getBrokerPort(),
                 "pulsar");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.pulsar", "embeddedPulsarToxiProxyInfo", environment);
+        return proxy;
     }
 
     @Bean(name = EMBEDDED_PULSAR)
-    public PulsarContainer embeddedPulsar(PulsarProperties pulsarProperties,
+    public PulsarContainer embeddedPulsar(ConfigurableEnvironment environment,
+                                          PulsarProperties pulsarProperties,
                                           @Deprecated @Value("${embedded.pulsar.imageTag:#{null}}") String deprImageTag,
                                           Optional<Network> network) {
         if (deprImageTag != null) {
@@ -57,28 +63,24 @@ public class EmbeddedPulsarBootstrapConfiguration {
 
         network.ifPresent(pulsarContainer::withNetwork);
         pulsarContainer = (PulsarContainer) ContainerUtils.configureCommonsAndStart(pulsarContainer, pulsarProperties, log);
+        registerPulsarEnvironment(pulsarContainer, environment, pulsarProperties);
         return pulsarContainer;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar pulsarDynamicPropertyRegistrar(
-            @Qualifier(EMBEDDED_PULSAR) PulsarContainer pulsarContainer,
-            PulsarProperties properties) {
-        return registry -> {
-            registry.add("embedded.pulsar.brokerUrl", pulsarContainer::getPulsarBrokerUrl);
-            registry.add("embedded.pulsar.httpServiceUrl", pulsarContainer::getHttpServiceUrl);
-            registry.add("embedded.pulsar.networkAlias", () -> PULSAR_NETWORK_ALIAS);
-            registry.add("embedded.pulsar.internalBrokerPort", properties::getBrokerPort);
+    private void registerPulsarEnvironment(PulsarContainer pulsarContainer,
+                                           ConfigurableEnvironment environment,
+                                           PulsarProperties properties) {
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.pulsar.brokerUrl", pulsarContainer.getPulsarBrokerUrl());
+        map.put("embedded.pulsar.httpServiceUrl", pulsarContainer.getHttpServiceUrl());
+        map.put("embedded.pulsar.networkAlias", PULSAR_NETWORK_ALIAS);
+        map.put("embedded.pulsar.internalBrokerPort", properties.getBrokerPort());
 
-            log.info("Started Pulsar. brokerUrl={}, httpServiceUrl={}",
-                    pulsarContainer.getPulsarBrokerUrl(), pulsarContainer.getHttpServiceUrl());
-        };
+        log.info("Started Pulsar. brokerUrl={}, httpServiceUrl={}",
+                pulsarContainer.getPulsarBrokerUrl(), pulsarContainer.getHttpServiceUrl());
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedPulsarInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "pulsar")
-    public DynamicPropertyRegistrar pulsarToxiProxyDynamicPropertyRegistrar(
-            @Qualifier("pulsarContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.pulsar");
-    }
 }

--- a/embedded-rabbitmq/src/main/java/com/playtika/testcontainer/rabbitmq/EmbeddedRabbitMQBootstrapConfiguration.java
+++ b/embedded-rabbitmq/src/main/java/com/playtika/testcontainer/rabbitmq/EmbeddedRabbitMQBootstrapConfiguration.java
@@ -14,7 +14,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.containers.ToxiproxyContainer;
@@ -42,23 +43,21 @@ public class EmbeddedRabbitMQBootstrapConfiguration {
     ToxiproxyClientProxy rabbitmqContainerProxy(ToxiproxyClient toxiproxyClient,
                                                  ToxiproxyContainer toxiproxyContainer,
                                                  @Qualifier(BEAN_NAME_EMBEDDED_RABBITMQ) RabbitMQContainer rabbitmq,
-                                                 RabbitMQProperties properties) {
-        return ToxiproxyHelper.createProxy(
+                                                 RabbitMQProperties properties,
+                                                 ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 rabbitmq,
                 properties.getPort(),
                 "rabbitmq");
-    }
-
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "rabbitmq")
-    public DynamicPropertyRegistrar rabbitmqToxiProxyDynamicPropertyRegistrar(@Qualifier("rabbitmqContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.rabbitmq");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.rabbitmq", "embeddedRabbitmqToxiProxyInfo", environment);
+        return proxy;
     }
 
     @Bean(name = BEAN_NAME_EMBEDDED_RABBITMQ, destroyMethod = "stop")
-    public RabbitMQContainer rabbitmq(RabbitMQProperties properties,
+    public RabbitMQContainer rabbitmq(ConfigurableEnvironment environment,
+                                      RabbitMQProperties properties,
                                       Optional<Network> network) {
         Integer[] exposedPorts = Stream.concat(properties.getAdditionalPorts().stream(), Stream.of(properties.getPort(), properties.getHttpPort()))
                 .distinct()
@@ -77,6 +76,13 @@ public class EmbeddedRabbitMQBootstrapConfiguration {
 
         network.ifPresent(rabbitMQ::withNetwork);
         rabbitMQ = (RabbitMQContainer) configureCommonsAndStart(rabbitMQ, properties, log);
+        registerRabbitMQEnvironment(rabbitMQ, environment, properties);
+        return rabbitMQ;
+    }
+
+    private void registerRabbitMQEnvironment(RabbitMQContainer rabbitMQ,
+                                             ConfigurableEnvironment environment,
+                                             RabbitMQProperties properties) {
         Integer mappedPort = rabbitMQ.getMappedPort(properties.getPort());
         Integer mappedHttpPort = rabbitMQ.getMappedPort(properties.getHttpPort());
         Map<Integer, Integer> additionalPorts = new LinkedHashMap<>();
@@ -84,27 +90,27 @@ public class EmbeddedRabbitMQBootstrapConfiguration {
             additionalPorts.put(port, rabbitMQ.getMappedPort(port));
         }
         String host = rabbitMQ.getHost();
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.rabbitmq.port", mappedPort);
+        map.put("embedded.rabbitmq.host", host);
+        map.put("embedded.rabbitmq.vhost", properties.getVhost());
+        map.put("embedded.rabbitmq.user", rabbitMQ.getAdminUsername());
+        map.put("embedded.rabbitmq.password", rabbitMQ.getAdminPassword());
+        map.put("embedded.rabbitmq.httpPort", mappedHttpPort);
+        map.put("embedded.rabbitmq.networkAlias", RABBITMQ_NETWORK_ALIAS);
+        map.put("embedded.rabbitmq.internalPort", properties.getPort());
+        map.put("embedded.rabbitmq.internalHttpPort", properties.getHttpPort());
+        for (Integer port : properties.getAdditionalPorts()) {
+            int mapped = rabbitMQ.getMappedPort(port);
+            map.put("embedded.rabbitmq.additionalPorts." + port, mapped);
+        }
+
         log.info("Started RabbitMQ server. Connection details: port={}, host={}, vhost={}, user={}, password={}, httpPort={}, networkAlias={}, internalPort={}, internalHttpPort={}, additionalPorts={}",
                 mappedPort, host, properties.getVhost(), rabbitMQ.getAdminUsername(), rabbitMQ.getAdminPassword(), mappedHttpPort, RABBITMQ_NETWORK_ALIAS, properties.getPort(), properties.getHttpPort(), additionalPorts);
-        return rabbitMQ;
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedRabbitmqInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 
-    @Bean
-    public DynamicPropertyRegistrar rabbitmqDynamicPropertyRegistrar(@Qualifier(BEAN_NAME_EMBEDDED_RABBITMQ) RabbitMQContainer rabbitMQ, RabbitMQProperties properties) {
-        return registry -> {
-            registry.add("embedded.rabbitmq.port", () -> rabbitMQ.getMappedPort(properties.getPort()));
-            registry.add("embedded.rabbitmq.host", rabbitMQ::getHost);
-            registry.add("embedded.rabbitmq.vhost", properties::getVhost);
-            registry.add("embedded.rabbitmq.user", rabbitMQ::getAdminUsername);
-            registry.add("embedded.rabbitmq.password", rabbitMQ::getAdminPassword);
-            registry.add("embedded.rabbitmq.httpPort", () -> rabbitMQ.getMappedPort(properties.getHttpPort()));
-            registry.add("embedded.rabbitmq.networkAlias", () -> RABBITMQ_NETWORK_ALIAS);
-            registry.add("embedded.rabbitmq.internalPort", properties::getPort);
-            registry.add("embedded.rabbitmq.internalHttpPort", properties::getHttpPort);
-            for (Integer port : properties.getAdditionalPorts()) {
-                int mapped = rabbitMQ.getMappedPort(port);
-                registry.add("embedded.rabbitmq.additionalPorts." + port, () -> mapped);
-            }
-        };
-    }
 }

--- a/embedded-redis/src/main/java/com/playtika/testcontainer/redis/EmbeddedRedisBootstrapConfiguration.java
+++ b/embedded-redis/src/main/java/com/playtika/testcontainer/redis/EmbeddedRedisBootstrapConfiguration.java
@@ -19,8 +19,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.io.ResourceLoader;
-import org.springframework.test.context.DynamicPropertyRegistrar;
 import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -30,6 +31,7 @@ import org.testcontainers.utility.MountableFile;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -64,31 +66,30 @@ public class EmbeddedRedisBootstrapConfiguration {
         return new DefaultRedisClusterWaitStrategy(properties);
     }
 
+
+
     @Bean
     @ConditionalOnToxiProxyEnabled(module = "redis")
     ToxiproxyClientProxy redisContainerProxy(ToxiproxyClient toxiproxyClient,
                                               ToxiproxyContainer toxiproxyContainer,
                                               @Qualifier(BEAN_NAME_EMBEDDED_REDIS) GenericContainer<?> redis,
-                                              RedisProperties properties) {
-
-
-        return ToxiproxyHelper.createProxy(
+                                              RedisProperties properties,
+                                              ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 redis,
                 properties.getPort(),
                 "redis");
-    }
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "redis")
-    public DynamicPropertyRegistrar redisToxiProxyDynamicPropertyRegistrar(
-            @Qualifier("redisContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.redis");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.redis", "embeddedRedisToxiProxyInfo", environment);
+
+        return proxy;
     }
 
     @Bean(name = BEAN_NAME_EMBEDDED_REDIS, destroyMethod = "stop")
     public GenericContainer<?> redis(@Qualifier(REDIS_WAIT_STRATEGY_BEAN_NAME) WaitStrategy redisStartupCheckStrategy,
+                                     ConfigurableEnvironment environment,
                                      Optional<Network> network) throws Exception {
         GenericContainer<?> redis =
                 new FixedHostPortGenericContainer(ContainerUtils.getDockerImageName(properties).asCanonicalNameString())
@@ -103,18 +104,22 @@ public class EmbeddedRedisBootstrapConfiguration {
                         .withNetworkAliases(REDIS_NETWORK_ALIAS);
         network.ifPresent(redis::withNetwork);
         redis = configureCommonsAndStart(redis, properties, log);
+        registerRedisEnvironment(redis, environment, properties);
         return redis;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar redisDynamicPropertyRegistrar(@Qualifier(BEAN_NAME_EMBEDDED_REDIS) GenericContainer<?> redis, RedisProperties properties) {
-        return registry -> {
-            registry.add("embedded.redis.port", properties::getPort);
-            registry.add("embedded.redis.host", redis::getHost);
-            registry.add("embedded.redis.password", properties::getPassword);
-            registry.add("embedded.redis.user", properties::getUser);
-            registry.add("embedded.redis.networkAlias", () -> REDIS_NETWORK_ALIAS);
-        };
+    private void registerRedisEnvironment(GenericContainer<?> redis, ConfigurableEnvironment environment, RedisProperties properties) {
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.redis.port", properties.getPort());
+        map.put("embedded.redis.host", redis.getHost());
+        map.put("embedded.redis.password", properties.getPassword());
+        map.put("embedded.redis.user", properties.getUser());
+        map.put("embedded.redis.networkAlias", REDIS_NETWORK_ALIAS);
+
+        log.info("Started Redis. Connection details: {}", map);
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedRedisInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 
     private Path prepareRedisConf() throws IOException {

--- a/embedded-selenium/src/main/java/com/playtika/testcontainer/selenium/EmbeddedSeleniumBootstrapConfiguration.java
+++ b/embedded-selenium/src/main/java/com/playtika/testcontainer/selenium/EmbeddedSeleniumBootstrapConfiguration.java
@@ -8,14 +8,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxOptions;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.BrowserWebDriverContainer;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.ContainerLaunchException;
@@ -80,6 +80,7 @@ public class EmbeddedSeleniumBootstrapConfiguration {
     @Bean(name = BEAN_NAME_EMBEDDED_SELENIUM, destroyMethod = "stop")
     @ConditionalOnMissingBean
     public BrowserWebDriverContainer selenium(
+                                              ConfigurableEnvironment environment,
                                               SeleniumProperties properties,
                                               MutableCapabilities capabilities,
                                               Optional<Network> network) {
@@ -101,7 +102,7 @@ public class EmbeddedSeleniumBootstrapConfiguration {
 
         ContainerUtils.configureCommonsAndStart(container, properties, log);
 
-        Map<String, Object> seleniumEnv = registerSeleniumEnvironment(container, properties.getVnc().getMode().convert(), recordingDirOrNull);
+        Map<String, Object> seleniumEnv = registerSeleniumEnvironment(container, environment, properties.getVnc().getMode().convert(), recordingDirOrNull);
         log.info("Started Selenium server. Connection details: {}", seleniumEnv);
         return container;
     }
@@ -152,7 +153,7 @@ public class EmbeddedSeleniumBootstrapConfiguration {
         return new DefaultRecordingFileFactory();
     }
 
-    private Map<String, Object> registerSeleniumEnvironment(BrowserWebDriverContainer container, BrowserWebDriverContainer.VncRecordingMode vncMode, File recordingDirOrNull) {
+    private Map<String, Object> registerSeleniumEnvironment(BrowserWebDriverContainer container, ConfigurableEnvironment environment, BrowserWebDriverContainer.VncRecordingMode vncMode, File recordingDirOrNull) {
         URL seleniumAddress = container.getSeleniumAddress();
         String vncAddress = container.getVncAddress();
         URI vncURI = URI.create(vncAddress);
@@ -168,6 +169,9 @@ public class EmbeddedSeleniumBootstrapConfiguration {
         map.put("embedded.selenium.vnc.mode", vncMode);
         map.put("embedded.selenium.dockerhost", getHostName(container));
         map.put("embedded.selenium.networkAlias", SELENIUM_NETWORK_ALIAS);
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedSeleniumInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
 
         return map;
     }
@@ -224,27 +228,4 @@ public class EmbeddedSeleniumBootstrapConfiguration {
         return str != null && !str.trim().isEmpty();
     }
 
-    @Bean
-    public DynamicPropertyRegistrar seleniumDynamicPropertyRegistrar(@Qualifier(BEAN_NAME_EMBEDDED_SELENIUM) BrowserWebDriverContainer selenium,
-                                                                    SeleniumProperties properties) {
-        return registry -> {
-            URL seleniumAddress = selenium.getSeleniumAddress();
-            String vncAddress = selenium.getVncAddress();
-            URI vncURI = URI.create(vncAddress);
-            registry.add("embedded.selenium.port", seleniumAddress::getPort);
-            registry.add("embedded.selenium.host", seleniumAddress::getHost);
-            registry.add("embedded.selenium.vnc.port", vncURI::getPort);
-            registry.add("embedded.selenium.vnc.host", vncURI::getHost);
-            registry.add("embedded.selenium.vnc.username", () -> DEFINED_VNC_USERNAME);
-            registry.add("embedded.selenium.vnc.password", () -> DEFINED_VNC_PASSWORD);
-            registry.add("embedded.selenium.vnc.recording-dir", () -> properties.getVnc().getRecordingDir());
-            registry.add("embedded.selenium.vnc.mode", () -> properties.getVnc().getMode());
-            registry.add("embedded.selenium.dockerhost", () -> getHostName(selenium));
-            registry.add("embedded.selenium.networkAlias", () -> SELENIUM_NETWORK_ALIAS);
-            log.info("Started Selenium server. Connection details: port={}, host={}, vnc.port={}, vnc.host={}, vnc.username={}, vnc.password={}, vnc.recording-dir={}, vnc.mode={}, dockerhost={}, networkAlias={}",
-                seleniumAddress.getPort(), seleniumAddress.getHost(), vncURI.getPort(), vncURI.getHost(),
-                DEFINED_VNC_USERNAME, DEFINED_VNC_PASSWORD, properties.getVnc().getRecordingDir(), properties.getVnc().getMode(),
-                getHostName(selenium), SELENIUM_NETWORK_ALIAS);
-        };
-    }
 }

--- a/embedded-solr/src/main/java/com/playtika/testcontainer/solr/EmbeddedSolrBootstrapConfiguration.java
+++ b/embedded-solr/src/main/java/com/playtika/testcontainer/solr/EmbeddedSolrBootstrapConfiguration.java
@@ -14,12 +14,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.SolrContainer;
 import org.testcontainers.containers.ToxiproxyContainer;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -40,24 +42,23 @@ public class EmbeddedSolrBootstrapConfiguration {
     ToxiproxyClientProxy solrContainerProxy(ToxiproxyClient toxiproxyClient,
                                              ToxiproxyContainer toxiproxyContainer,
                                              @Qualifier(BEAN_NAME_EMBEDDED_SOLR) SolrContainer solrContainer,
-                                             SolrProperties properties) {
+                                             SolrProperties properties,
+                                             ConfigurableEnvironment environment) {
 
-        return ToxiproxyHelper.createProxy(
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 solrContainer,
                 properties.getPort(),
                 "solr");
-    }
-
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "solr")
-    public DynamicPropertyRegistrar solrToxiProxyDynamicPropertyRegistrar(@Qualifier("solrContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.solr");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.solr", "embeddedSolrToxiProxyInfo", environment);
+        return proxy;
     }
 
     @Bean(name = BEAN_NAME_EMBEDDED_SOLR, destroyMethod = "stop")
-    public GenericContainer<?> solrContainer(SolrProperties properties, Optional<Network> network) {
+    public GenericContainer<?> solrContainer(ConfigurableEnvironment environment,
+                                             SolrProperties properties,
+                                             Optional<Network> network) {
         SolrContainer solrContainer = new SolrContainer(ContainerUtils.getDockerImageName(properties))
                 .withExposedPorts(properties.getPort())
                 .withNetworkAliases(SOLR_NETWORK_ALIAS);
@@ -65,20 +66,24 @@ public class EmbeddedSolrBootstrapConfiguration {
         network.ifPresent(solrContainer::withNetwork);
 
         solrContainer = (SolrContainer) configureCommonsAndStart(solrContainer, properties, log);
-
+        registerSolrEnvironment(solrContainer, environment, properties);
         return solrContainer;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar solrDynamicPropertyRegistrar(@Qualifier(BEAN_NAME_EMBEDDED_SOLR) GenericContainer<?> natsContainer, SolrProperties properties) {
-        return registry -> {
-            Integer port = natsContainer.getMappedPort(properties.getPort());
-            String host = natsContainer.getHost();
-            registry.add("embedded.solr.host", () -> host);
-            registry.add("embedded.solr.port", () -> port);
-            registry.add("embedded.solr.networkAlias", () -> SOLR_NETWORK_ALIAS);
-            registry.add("embedded.solr.internalPort", properties::getPort);
-        };
+    private void registerSolrEnvironment(SolrContainer solrContainer,
+                                         ConfigurableEnvironment environment,
+                                         SolrProperties properties) {
+        Integer port = solrContainer.getMappedPort(properties.getPort());
+        String host = solrContainer.getHost();
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.solr.host", host);
+        map.put("embedded.solr.port", port);
+        map.put("embedded.solr.networkAlias", SOLR_NETWORK_ALIAS);
+        map.put("embedded.solr.internalPort", properties.getPort());
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedSolrInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 
 }

--- a/embedded-spicedb/src/main/java/com/playtika/testcontainer/spicedb/EmbeddedSpiceDBBootstrapConfiguration.java
+++ b/embedded-spicedb/src/main/java/com/playtika/testcontainer/spicedb/EmbeddedSpiceDBBootstrapConfiguration.java
@@ -15,7 +15,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
@@ -23,6 +24,7 @@ import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -43,18 +45,21 @@ public class EmbeddedSpiceDBBootstrapConfiguration {
     ToxiproxyClientProxy spicedbContainerProxy(ToxiproxyClient toxiproxyClient,
                                                 ToxiproxyContainer toxiproxyContainer,
                                                 @Qualifier(BEAN_NAME_EMBEDDED_SPICEDB) GenericContainer<?> spicedbContainer,
-                                                SpiceDBProperties properties) {
-
-        return ToxiproxyHelper.createProxy(
+                                                SpiceDBProperties properties,
+                                                ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 spicedbContainer,
                 properties.getPort(),
                 "spicedb");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.spicedb", "embeddedSpicedbToxiProxyInfo", environment);
+        return proxy;
     }
 
     @Bean(name = BEAN_NAME_EMBEDDED_SPICEDB, destroyMethod = "stop")
-    public GenericContainer<?> spicedb(SpiceDBProperties properties,
+    public GenericContainer<?> spicedb(ConfigurableEnvironment environment,
+                                       SpiceDBProperties properties,
                                        Optional<Network> network) {
         WaitStrategy waitStrategy = new WaitAllStrategy()
             .withStrategy(new HostPortWaitStrategy())
@@ -69,28 +74,21 @@ public class EmbeddedSpiceDBBootstrapConfiguration {
         network.ifPresent(spicedbContainer::withNetwork);
 
         spicedbContainer = configureCommonsAndStart(spicedbContainer, properties, log);
-
+        registerSpiceDBEnvironment(spicedbContainer, environment, properties);
         return spicedbContainer;
     }
 
+    private void registerSpiceDBEnvironment(GenericContainer<?> spicedb,
+                                            ConfigurableEnvironment environment,
+                                            SpiceDBProperties properties) {
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.spicedb.host", spicedb.getHost());
+        map.put("embedded.spicedb.port", spicedb.getMappedPort(properties.getPort()));
+        map.put("embedded.spicedb.networkAlias", "spicedb.testcontainer.docker");
+        map.put("embedded.spicedb.token", properties.getPresharedKey());
+        map.put("embedded.spicedb.internalPort", properties.getPort());
 
-    @Bean
-    public DynamicPropertyRegistrar spicedbDynamicPropertyRegistrar(
-            @Qualifier(BEAN_NAME_EMBEDDED_SPICEDB) GenericContainer<?> spicedb,
-            SpiceDBProperties properties) {
-        return registry -> {
-            registry.add("embedded.spicedb.host", spicedb::getHost);
-            registry.add("embedded.spicedb.port", () -> spicedb.getMappedPort(properties.getPort()));
-            registry.add("embedded.spicedb.networkAlias", () -> "spicedb.testcontainer.docker");
-            registry.add("embedded.spicedb.token", properties::getPresharedKey);
-            registry.add("embedded.spicedb.internalPort", properties::getPort);
-        };
-    }
-
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "spicedb")
-    public DynamicPropertyRegistrar spicedbToxiProxyDynamicPropertyRegistrar(
-            @Qualifier("spicedbContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.spicedb");
+        MapPropertySource propertySource = new MapPropertySource("embeddedSpicedbInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 }

--- a/embedded-temporal/src/main/java/com/playtika/testcontainer/temporal/EmbeddedTemporalBootstrapConfiguration.java
+++ b/embedded-temporal/src/main/java/com/playtika/testcontainer/temporal/EmbeddedTemporalBootstrapConfiguration.java
@@ -3,18 +3,19 @@ package com.playtika.testcontainer.temporal;
 import com.playtika.testcontainer.common.spring.DockerPresenceBootstrapConfiguration;
 import com.playtika.testcontainer.common.utils.ContainerUtils;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -36,7 +37,9 @@ public class EmbeddedTemporalBootstrapConfiguration {
     private static final String TEMPORAL_NETWORK_ALIAS = "temporal.testcontainer.docker";
 
     @Bean(value = BEAN_NAME_EMBEDDED_TEMPORAL, destroyMethod = "stop")
-    public GenericContainer<?> temporal(TemporalProperties properties, Optional<Network> network) {
+    public GenericContainer<?> temporal(ConfigurableEnvironment environment,
+                                        TemporalProperties properties,
+                                        Optional<Network> network) {
         GenericContainer<?> container =
                 new GenericContainer<>(ContainerUtils.getDockerImageName(properties))
                         .withCreateContainerCmdModifier(cmd -> cmd.withEntrypoint(
@@ -60,23 +63,27 @@ public class EmbeddedTemporalBootstrapConfiguration {
         network.ifPresent(container::withNetwork);
 
         configureCommonsAndStart(container, properties, log);
-
+        registerTemporalEnvironment(container, environment, properties);
         return container;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar temporalDynamicPropertyRegistrar(@Qualifier(BEAN_NAME_EMBEDDED_TEMPORAL) GenericContainer<?> container, TemporalProperties properties) {
-        return registry -> {
-            String host = container.getHost();
-            Integer port = container.getMappedPort(INTERNAL_PORT);
-            registry.add("embedded.temporal.host", () -> host);
-            registry.add("embedded.temporal.port", () -> port);
-            registry.add("embedded.temporal.networkAlias", () -> TEMPORAL_NETWORK_ALIAS);
-            registry.add("embedded.temporal.internalPort", () -> INTERNAL_PORT);
-            if (properties.isUiEnabled()) {
-                Integer uiPort = container.getMappedPort(INTERNAL_UI_PORT);
-                registry.add("embedded.temporal.uiPort", () -> uiPort);
-            }
-        };
+    private void registerTemporalEnvironment(GenericContainer<?> container,
+                                             ConfigurableEnvironment environment,
+                                             TemporalProperties properties) {
+        String host = container.getHost();
+        Integer port = container.getMappedPort(INTERNAL_PORT);
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.temporal.host", host);
+        map.put("embedded.temporal.port", port);
+        map.put("embedded.temporal.networkAlias", TEMPORAL_NETWORK_ALIAS);
+        map.put("embedded.temporal.internalPort", INTERNAL_PORT);
+        if (properties.isUiEnabled()) {
+            Integer uiPort = container.getMappedPort(INTERNAL_UI_PORT);
+            map.put("embedded.temporal.uiPort", uiPort);
+        }
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedTemporalInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 }

--- a/embedded-toxiproxy/src/main/java/com/playtika/testcontainer/toxiproxy/EmbeddedToxiProxyBootstrapConfiguration.java
+++ b/embedded-toxiproxy/src/main/java/com/playtika/testcontainer/toxiproxy/EmbeddedToxiProxyBootstrapConfiguration.java
@@ -5,16 +5,18 @@ import com.playtika.testcontainer.common.utils.ContainerUtils;
 import com.playtika.testcontainer.toxiproxy.condition.ConditionalOnToxiProxyEnabled;
 import eu.rekawek.toxiproxy.ToxiproxyClient;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
+
+import java.util.LinkedHashMap;
 
 @Slf4j
 @Configuration
@@ -38,23 +40,27 @@ public class EmbeddedToxiProxyBootstrapConfiguration {
 
     @Bean(name = "toxiproxy", destroyMethod = "stop")
     ToxiproxyContainer toxiproxy(ToxiProxyProperties toxiProxyProperties,
-                                 Network network) {
+                                 Network network,
+                                 ConfigurableEnvironment environment) {
         ToxiproxyContainer toxiproxyContainer = new ToxiproxyContainer(ContainerUtils.getDockerImageName(toxiProxyProperties))
                 .withNetwork(network)
                 .withNetworkAliases(TOXIPROXY_NETWORK_ALIAS, TOXIPROXY_NETWORK_ALIAS_OLD);
 
         toxiproxyContainer = (ToxiproxyContainer) ContainerUtils.configureCommonsAndStart(toxiproxyContainer, toxiProxyProperties, log);
+        registerToxiproxyEnvironment(toxiproxyContainer, environment);
         return toxiproxyContainer;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar toxiproxyDynamicPropertyRegistrar(
-            @Qualifier("toxiproxy") ToxiproxyContainer toxiproxy) {
-        return registry -> {
-            registry.add("embedded.toxiproxy.host", toxiproxy::getHost);
-            registry.add("embedded.toxiproxy.controlPort", toxiproxy::getControlPort);
-            registry.add("embedded.toxiproxy.networkAlias", () -> TOXIPROXY_NETWORK_ALIAS);
-        };
+    private void registerToxiproxyEnvironment(ToxiproxyContainer toxiproxy, ConfigurableEnvironment environment) {
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.toxiproxy.host", toxiproxy.getHost());
+        map.put("embedded.toxiproxy.controlPort", toxiproxy.getControlPort());
+        map.put("embedded.toxiproxy.networkAlias", TOXIPROXY_NETWORK_ALIAS);
+
+        log.info("Started Toxiproxy. Connection details: {}", map);
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedToxiproxyInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 
     @Bean

--- a/embedded-toxiproxy/src/main/java/com/playtika/testcontainer/toxiproxy/ToxiproxyHelper.java
+++ b/embedded-toxiproxy/src/main/java/com/playtika/testcontainer/toxiproxy/ToxiproxyHelper.java
@@ -4,11 +4,14 @@ import eu.rekawek.toxiproxy.Proxy;
 import eu.rekawek.toxiproxy.ToxiproxyClient;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.ToxiproxyContainer;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -122,13 +125,32 @@ public class ToxiproxyHelper {
                 .orElseThrow(() -> new IllegalStateException("Cannot determine upstream address for container"));
     }
 
-     public static DynamicPropertyRegistrar createToxiProxyDynamicPropertyRegistrar(
-            ToxiproxyClientProxy proxy,
-            String propertyPrefix) {
-        return registry -> {
-            registry.add(propertyPrefix + ".toxiproxy.host", proxy::getContainerIpAddress);
-            registry.add(propertyPrefix + ".toxiproxy.port", proxy::getProxyPort);
-            registry.add(propertyPrefix + ".toxiproxy.proxyName", proxy::getName);
-        };
+    /**
+     * Registers environment properties for a toxiproxy connection
+     */
+    public static void registerProxyEnvironment(ToxiproxyClientProxy proxy,
+                                                 String propertyPrefix,
+                                                 String propertySourceName,
+                                                 ConfigurableEnvironment environment) {
+        registerProxyEnvironment(proxy, propertyPrefix, propertySourceName, environment, "port");
+    }
+
+    /**
+     * Registers environment properties for a toxiproxy connection with a custom port key.
+     * This is useful for cases like Azurite which has multiple ports (blobStoragePort, queueStoragePort, etc.)
+     */
+    public static void registerProxyEnvironment(ToxiproxyClientProxy proxy,
+                                                 String propertyPrefix,
+                                                 String propertySourceName,
+                                                 ConfigurableEnvironment environment,
+                                                 String portKey) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put(propertyPrefix + ".toxiproxy.host", proxy.getContainerIpAddress());
+        map.put(propertyPrefix + ".toxiproxy." + portKey, proxy.getProxyPort());
+        map.put(propertyPrefix + ".toxiproxy.proxyName", proxy.getName());
+
+        MapPropertySource propertySource = new MapPropertySource(propertySourceName, map);
+        environment.getPropertySources().addFirst(propertySource);
+        log.info("Started {} ToxiProxy connection details {}", propertyPrefix, map);
     }
 }

--- a/embedded-vault/src/main/java/com/playtika/testcontainer/vault/EmbeddedVaultBootstrapConfiguration.java
+++ b/embedded-vault/src/main/java/com/playtika/testcontainer/vault/EmbeddedVaultBootstrapConfiguration.java
@@ -15,12 +15,14 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.vault.VaultContainer;
 
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
 
@@ -44,18 +46,21 @@ public class EmbeddedVaultBootstrapConfiguration {
     ToxiproxyClientProxy vaultContainerProxy(ToxiproxyClient toxiproxyClient,
                                               ToxiproxyContainer toxiproxyContainer,
                                               @Qualifier(BEAN_NAME_EMBEDDED_VAULT) VaultContainer vault,
-                                              VaultProperties properties) {
-
-        return ToxiproxyHelper.createProxy(
+                                              VaultProperties properties,
+                                              ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 vault,
                 properties.getPort(),
                 "vault");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.vault", "embeddedVaultToxiProxyInfo", environment);
+        return proxy;
     }
 
     @Bean(name = BEAN_NAME_EMBEDDED_VAULT, destroyMethod = "stop")
-    public VaultContainer vault(VaultProperties properties,
+    public VaultContainer vault(ConfigurableEnvironment environment,
+                                VaultProperties properties,
                                 Optional<Network> network) {
 
         VaultContainer vault = new VaultContainer<>(ContainerUtils.getDockerImageName(properties))
@@ -83,53 +88,42 @@ public class EmbeddedVaultBootstrapConfiguration {
         }
 
         vault = (VaultContainer) configureCommonsAndStart(vault, properties, log);
-
-        // Set Spring Cloud Vault properties as system properties for bootstrap phase
-        // These are needed for Spring Cloud Vault to initialize during bootstrap
-        // The actual configuration structure is in application-test.yml
-        Integer mappedPort = vault.getMappedPort(properties.getPort());
-        String host = vault.getHost();
-        System.setProperty("spring.cloud.vault.host", host);
-        System.setProperty("spring.cloud.vault.port", String.valueOf(mappedPort));
-        System.setProperty("spring.cloud.vault.token", properties.getToken());
-        System.setProperty("spring.cloud.vault.scheme", "http");
-        System.setProperty("spring.cloud.vault.kv.enabled", "true");
-
+        registerVaultEnvironment(vault, environment, properties);
         return vault;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar vaultDynamicPropertyRegistrar(
-            @Qualifier(BEAN_NAME_EMBEDDED_VAULT) VaultContainer vault,
-            VaultProperties properties) {
-        return registry -> {
-            Integer mappedPort = vault.getMappedPort(properties.getPort());
-            String host = vault.getHost();
-            String token = properties.getToken();
+    private void registerVaultEnvironment(VaultContainer vault,
+                                          ConfigurableEnvironment environment,
+                                          VaultProperties properties) {
+        Integer mappedPort = vault.getMappedPort(properties.getPort());
+        String host = vault.getHost();
+        String token = properties.getToken();
 
-            registry.add("embedded.vault.host", () -> host);
-            registry.add("embedded.vault.port", () -> mappedPort);
-            registry.add("embedded.vault.token", () -> token);
-            registry.add("embedded.vault.networkAlias", () -> VAULT_NETWORK_ALIAS);
-            registry.add("embedded.vault.internalPort", properties::getPort);
+        // Set Spring Cloud Vault properties as system properties for bootstrap phase
+        System.setProperty("spring.cloud.vault.host", host);
+        System.setProperty("spring.cloud.vault.port", String.valueOf(mappedPort));
+        System.setProperty("spring.cloud.vault.token", token);
+        System.setProperty("spring.cloud.vault.scheme", "http");
+        System.setProperty("spring.cloud.vault.kv.enabled", "true");
 
-            // Register Spring Cloud Vault properties for test context (application-test.yml references these)
-            registry.add("spring.cloud.vault.host", () -> host);
-            registry.add("spring.cloud.vault.port", () -> mappedPort);
-            registry.add("spring.cloud.vault.token", () -> token);
-            registry.add("spring.cloud.vault.scheme", () -> "http");
-            registry.add("spring.cloud.vault.kv.enabled", () -> "true");
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.vault.host", host);
+        map.put("embedded.vault.port", mappedPort);
+        map.put("embedded.vault.token", token);
+        map.put("embedded.vault.networkAlias", VAULT_NETWORK_ALIAS);
+        map.put("embedded.vault.internalPort", properties.getPort());
+        // Register Spring Cloud Vault properties for test context
+        map.put("spring.cloud.vault.host", host);
+        map.put("spring.cloud.vault.port", mappedPort);
+        map.put("spring.cloud.vault.token", token);
+        map.put("spring.cloud.vault.scheme", "http");
+        map.put("spring.cloud.vault.kv.enabled", "true");
 
-            log.info("Started vault. Connection Details: host={}, port={}, Connection URI: http://{}:{}",
-                    host, mappedPort, host, mappedPort);
-        };
-    }
+        log.info("Started vault. Connection Details: host={}, port={}, Connection URI: http://{}:{}",
+                host, mappedPort, host, mappedPort);
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "vault")
-    public DynamicPropertyRegistrar vaultToxiProxyDynamicPropertyRegistrar(
-            @Qualifier("vaultContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.vault");
+        MapPropertySource propertySource = new MapPropertySource("embeddedVaultInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 
     private void enableCasForSubPaths(List<String> subPaths, VaultContainer vault) {

--- a/embedded-vertica/src/main/java/com/playtika/testcontainer/vertica/EmbeddedVerticaBootstrapConfiguration.java
+++ b/embedded-vertica/src/main/java/com/playtika/testcontainer/vertica/EmbeddedVerticaBootstrapConfiguration.java
@@ -14,13 +14,15 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 
 import java.time.Duration;
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -42,23 +44,21 @@ public class EmbeddedVerticaBootstrapConfiguration {
     ToxiproxyClientProxy verticaContainerProxy(ToxiproxyClient toxiproxyClient,
                                                 ToxiproxyContainer toxiproxyContainer,
                                                 @Qualifier(BEAN_NAME_EMBEDDED_VERTICA) GenericContainer<?> embeddedVertica,
-                                               VerticaProperties verticaProperties) {
-        return ToxiproxyHelper.createProxy(
+                                               VerticaProperties verticaProperties,
+                                               ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 embeddedVertica,
                 verticaProperties.getPort(),
                 "vertica");
-    }
-
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "vertica")
-    public DynamicPropertyRegistrar verticaToxiProxyDynamicPropertyRegistrar(@Qualifier("verticaContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.vertica");
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.vertica", "embeddedVerticaToxiProxyInfo", environment);
+        return proxy;
     }
 
     @Bean(name = BEAN_NAME_EMBEDDED_VERTICA, destroyMethod = "stop")
-    public GenericContainer<?> embeddedVertica(VerticaProperties properties,
+    public GenericContainer<?> embeddedVertica(ConfigurableEnvironment environment,
+                                               VerticaProperties properties,
                                                Optional<Network> network) {
         GenericContainer<?> verticaContainer = new GenericContainer<>(ContainerUtils.getDockerImageName(properties))
             .withExposedPorts(properties.getPort())
@@ -72,25 +72,30 @@ public class EmbeddedVerticaBootstrapConfiguration {
         network.ifPresent(verticaContainer::withNetwork);
 
         verticaContainer = configureCommonsAndStart(verticaContainer, properties, log);
-
-        Integer mappedPort = verticaContainer.getMappedPort(properties.getPort());
-        String host = verticaContainer.getHost();
-        log.info("Started Vertica server. Connection details: port={}, host={}, database={}, user={}, password={}, networkAlias={}, internalPort={}",
-                mappedPort, host, properties.getDatabase(), properties.getUser(), properties.getPassword(), VERTICA_NETWORK_ALIAS, properties.getPort());
+        registerVerticaEnvironment(verticaContainer, environment, properties);
         return verticaContainer;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar verticaDynamicPropertyRegistrar(@Qualifier(BEAN_NAME_EMBEDDED_VERTICA) GenericContainer<?> verticaContainer, VerticaProperties properties) {
-        return registry -> {
-            registry.add("embedded.vertica.port", () -> verticaContainer.getMappedPort(properties.getPort()));
-            registry.add("embedded.vertica.host", verticaContainer::getHost);
-            registry.add("embedded.vertica.database", properties::getDatabase);
-            registry.add("embedded.vertica.user", properties::getUser);
-            registry.add("embedded.vertica.password", properties::getPassword);
-            registry.add("embedded.vertica.networkAlias", () -> VERTICA_NETWORK_ALIAS);
-            registry.add("embedded.vertica.internalPort", properties::getPort);
-        };
+    private void registerVerticaEnvironment(GenericContainer<?> verticaContainer,
+                                            ConfigurableEnvironment environment,
+                                            VerticaProperties properties) {
+        Integer mappedPort = verticaContainer.getMappedPort(properties.getPort());
+        String host = verticaContainer.getHost();
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.vertica.port", mappedPort);
+        map.put("embedded.vertica.host", host);
+        map.put("embedded.vertica.database", properties.getDatabase());
+        map.put("embedded.vertica.user", properties.getUser());
+        map.put("embedded.vertica.password", properties.getPassword());
+        map.put("embedded.vertica.networkAlias", VERTICA_NETWORK_ALIAS);
+        map.put("embedded.vertica.internalPort", properties.getPort());
+
+        log.info("Started Vertica server. Connection details: port={}, host={}, database={}, user={}, password={}, networkAlias={}, internalPort={}",
+                mappedPort, host, properties.getDatabase(), properties.getUser(), properties.getPassword(), VERTICA_NETWORK_ALIAS, properties.getPort());
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedVerticaInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 
 }

--- a/embedded-victoriametrics/src/main/java/com/playtika/testcontainer/victoriametrics/EmbeddedVictoriaMetricsBootstrapConfiguration.java
+++ b/embedded-victoriametrics/src/main/java/com/playtika/testcontainer/victoriametrics/EmbeddedVictoriaMetricsBootstrapConfiguration.java
@@ -16,13 +16,15 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.ToxiproxyContainer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -52,19 +54,22 @@ public class EmbeddedVictoriaMetricsBootstrapConfiguration {
     public ToxiproxyClientProxy victoriaMetricsContainerProxy(ToxiproxyClient toxiproxyClient,
                                                                ToxiproxyContainer toxiproxyContainer,
                                                                @Qualifier(BEAN_NAME_EMBEDDED_VICTORIA_METRICS) GenericContainer<?> victoriametrics,
-                                                               VictoriaMetricsProperties properties) {
-
-        return ToxiproxyHelper.createProxy(
+                                                               VictoriaMetricsProperties properties,
+                                                               ConfigurableEnvironment environment) {
+        ToxiproxyClientProxy proxy = ToxiproxyHelper.createProxy(
                 toxiproxyClient,
                 toxiproxyContainer,
                 victoriametrics,
                 properties.getPort(),
                 "victoriametrics"
         );
+        ToxiproxyHelper.registerProxyEnvironment(proxy, "embedded.victoriametrics", "embeddedVictoriametricsToxiProxyInfo", environment);
+        return proxy;
     }
 
     @Bean(name = BEAN_NAME_EMBEDDED_VICTORIA_METRICS, destroyMethod = "stop")
-    public GenericContainer<?> victoriaMetrics(VictoriaMetricsProperties properties,
+    public GenericContainer<?> victoriaMetrics(ConfigurableEnvironment environment,
+                                              VictoriaMetricsProperties properties,
                                               Optional<Network> network,
                                               WaitStrategy victoriaMetricsWaitStrategy) {
         GenericContainer<?> victoriaMetrics = new GenericContainer<>(ContainerUtils.getDockerImageName(properties))
@@ -73,25 +78,20 @@ public class EmbeddedVictoriaMetricsBootstrapConfiguration {
                 .waitingFor(victoriaMetricsWaitStrategy);
         network.ifPresent(victoriaMetrics::withNetwork);
         configureCommonsAndStart(victoriaMetrics, properties, log);
+        registerVictoriaMetricsEnvironment(victoriaMetrics, environment, properties);
         return victoriaMetrics;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar victoriaMetricsDynamicPropertyRegistrar(
-            @Qualifier(BEAN_NAME_EMBEDDED_VICTORIA_METRICS) GenericContainer<?> victoriaMetrics,
-            VictoriaMetricsProperties properties) {
-        return registry -> {
-            registry.add("embedded.victoriametrics.host", victoriaMetrics::getHost);
-            registry.add("embedded.victoriametrics.port", () -> victoriaMetrics.getMappedPort(properties.getPort()));
-            registry.add("embedded.victoriametrics.networkAlias", () -> VICTORIAMETRICS_NETWORK_ALIAS);
-            registry.add("embedded.victoriametrics.internalPort", () -> properties.getPort());
-        };
-    }
+    private void registerVictoriaMetricsEnvironment(GenericContainer<?> victoriaMetrics,
+                                                    ConfigurableEnvironment environment,
+                                                    VictoriaMetricsProperties properties) {
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.victoriametrics.host", victoriaMetrics.getHost());
+        map.put("embedded.victoriametrics.port", victoriaMetrics.getMappedPort(properties.getPort()));
+        map.put("embedded.victoriametrics.networkAlias", VICTORIAMETRICS_NETWORK_ALIAS);
+        map.put("embedded.victoriametrics.internalPort", properties.getPort());
 
-    @Bean
-    @ConditionalOnToxiProxyEnabled(module = "victoriametrics")
-    public DynamicPropertyRegistrar victoriaMetricsToxiProxyDynamicPropertyRegistrar(
-            @Qualifier("victoriaMetricsContainerProxy") ToxiproxyClientProxy proxy) {
-        return ToxiproxyHelper.createToxiProxyDynamicPropertyRegistrar(proxy, "embedded.victoriametrics");
+        MapPropertySource propertySource = new MapPropertySource("embeddedVictoriametricsInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 }

--- a/embedded-wiremock/src/main/java/com/playtika/testcontainers/wiremock/EmbeddedWiremockBootstrapConfiguration.java
+++ b/embedded-wiremock/src/main/java/com/playtika/testcontainers/wiremock/EmbeddedWiremockBootstrapConfiguration.java
@@ -3,19 +3,20 @@ package com.playtika.testcontainers.wiremock;
 import com.playtika.testcontainer.common.spring.DockerPresenceBootstrapConfiguration;
 import com.playtika.testcontainer.common.utils.ContainerUtils;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -35,7 +36,9 @@ public class EmbeddedWiremockBootstrapConfiguration {
             .forStatusCode(200);
 
     @Bean(name = BEAN_NAME_EMBEDDED_WIREMOCK, destroyMethod = "stop")
-    public GenericContainer<?> wiremock(WiremockProperties properties, Optional<Network> network) {
+    public GenericContainer<?> wiremock(ConfigurableEnvironment environment,
+                                        WiremockProperties properties,
+                                        Optional<Network> network) {
         GenericContainer<?> wiremock =
             new GenericContainer<>(ContainerUtils.getDockerImageName(properties))
                 .waitingFor(DEFAULT_WAITER)
@@ -44,22 +47,24 @@ public class EmbeddedWiremockBootstrapConfiguration {
                 .withNetworkAliases(WIREMOCK_NETWORK_ALIAS);
         network.ifPresent(wiremock::withNetwork);
         configureCommonsAndStart(wiremock, properties, log);
+        registerWiremockEnvironment(wiremock, environment, properties);
         return wiremock;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar wiremockDynamicPropertyRegistrar(
-            @Qualifier(BEAN_NAME_EMBEDDED_WIREMOCK) GenericContainer<?> container,
-            WiremockProperties properties) {
-        return registry -> {
-            registry.add("embedded.wiremock.host", container::getHost);
-            registry.add("embedded.wiremock.port", () -> container.getMappedPort(properties.getPort()));
-            registry.add("embedded.wiremock.networkAlias", () -> WIREMOCK_NETWORK_ALIAS);
-            registry.add("embedded.wiremock.internalPort", properties::getPort);
+    private void registerWiremockEnvironment(GenericContainer<?> container,
+                                             ConfigurableEnvironment environment,
+                                             WiremockProperties properties) {
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.wiremock.host", container.getHost());
+        map.put("embedded.wiremock.port", container.getMappedPort(properties.getPort()));
+        map.put("embedded.wiremock.networkAlias", WIREMOCK_NETWORK_ALIAS);
+        map.put("embedded.wiremock.internalPort", properties.getPort());
 
-            log.info("Started wiremock. Connection Details: embedded.wiremock.host={}, embedded.wiremock.port={}," +
-                     "embedded.wiremock.networkAlias={}, embedded.wiremock.internalPort={}",
-                container.getHost(), container.getMappedPort(properties.getPort()), WIREMOCK_NETWORK_ALIAS, properties.getPort());
-        };
+        log.info("Started wiremock. Connection Details: embedded.wiremock.host={}, embedded.wiremock.port={}," +
+                 "embedded.wiremock.networkAlias={}, embedded.wiremock.internalPort={}",
+            container.getHost(), container.getMappedPort(properties.getPort()), WIREMOCK_NETWORK_ALIAS, properties.getPort());
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedWiremockInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 }

--- a/embedded-zookeeper/src/main/java/com/playtika/testcontainers/zookeeper/EmbeddedZookeeperBootstrapConfiguration.java
+++ b/embedded-zookeeper/src/main/java/com/playtika/testcontainers/zookeeper/EmbeddedZookeeperBootstrapConfiguration.java
@@ -3,14 +3,14 @@ package com.playtika.testcontainers.zookeeper;
 import com.playtika.testcontainer.common.spring.DockerPresenceBootstrapConfiguration;
 import com.playtika.testcontainer.common.utils.ContainerUtils;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
@@ -18,6 +18,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
 
+import java.util.LinkedHashMap;
 import java.util.Optional;
 
 import static com.playtika.testcontainer.common.utils.ContainerUtils.configureCommonsAndStart;
@@ -33,7 +34,9 @@ public class EmbeddedZookeeperBootstrapConfiguration {
     private static final String ZOOKEEPER_NETWORK_ALIAS = "zookeeper.testcontainer.docker";
 
     @Bean(destroyMethod = "stop")
-    public GenericContainer<?> zooKeeperContainer(ZookeeperConfigurationProperties properties, Optional<Network> network) {
+    public GenericContainer<?> zooKeeperContainer(ConfigurableEnvironment environment,
+                                                  ZookeeperConfigurationProperties properties,
+                                                  Optional<Network> network) {
         WaitStrategy waitStrategy = new WaitAllStrategy()
                 .withStrategy(new HostPortWaitStrategy())
                 .withStrategy(Wait.forHttp("/commands/ruok")
@@ -49,19 +52,24 @@ public class EmbeddedZookeeperBootstrapConfiguration {
         network.ifPresent(zookeeper::withNetwork);
 
         zookeeper = configureCommonsAndStart(zookeeper, properties, log);
+        registerZookeeperEnvironment(zookeeper, environment, properties);
         return zookeeper;
     }
 
-    @Bean
-    public DynamicPropertyRegistrar zookeeperDynamicPropertyRegistrar(@Qualifier("zooKeeperContainer") GenericContainer<?> zookeeper, ZookeeperConfigurationProperties properties) {
-        return registry -> {
-            String host = zookeeper.getHost();
-            registry.add("embedded.zookeeper.port", () -> zookeeper.getMappedPort(properties.clientPort));
-            registry.add("embedded.zookeeper.admin.port", () -> zookeeper.getMappedPort(properties.adminServerPort));
-            registry.add("embedded.zookeeper.host", () -> host);
-            registry.add("embedded.zookeeper.networkAlias", () -> ZOOKEEPER_NETWORK_ALIAS);
-            registry.add("embedded.zookeeper.internalClientPort", properties::getClientPort);
-            registry.add("embedded.zookeeper.internalAdminServerPort", properties::getAdminServerPort);
-        };
+    private void registerZookeeperEnvironment(GenericContainer<?> zookeeper,
+                                              ConfigurableEnvironment environment,
+                                              ZookeeperConfigurationProperties properties) {
+        String host = zookeeper.getHost();
+
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        map.put("embedded.zookeeper.port", zookeeper.getMappedPort(properties.clientPort));
+        map.put("embedded.zookeeper.admin.port", zookeeper.getMappedPort(properties.adminServerPort));
+        map.put("embedded.zookeeper.host", host);
+        map.put("embedded.zookeeper.networkAlias", ZOOKEEPER_NETWORK_ALIAS);
+        map.put("embedded.zookeeper.internalClientPort", properties.getClientPort());
+        map.put("embedded.zookeeper.internalAdminServerPort", properties.getAdminServerPort());
+
+        MapPropertySource propertySource = new MapPropertySource("embeddedZookeeperInfo", map);
+        environment.getPropertySources().addFirst(propertySource);
     }
 }


### PR DESCRIPTION
DynamicPropertyRegistrar seems be processed too late in many scenarios. This partial revert keeps the removal of spring-cloud but restores the use of MapPropertySource. This simplier approach ensures that the properties are emitted as soon as the container is started.