### PR TITLE
Optimize YumPackageInstaller: Use 'rpm -q' instead of 'yum list installed

### DIFF
--- a/testcontainers-common/src/main/java/com/playtika/testcontainer/common/utils/PackageInstaller.java
+++ b/testcontainers-common/src/main/java/com/playtika/testcontainer/common/utils/PackageInstaller.java
@@ -66,4 +66,8 @@ public abstract class PackageInstaller implements InitializingBean {
         return ContainerUtils.executeAndCheckExitCode(container, command);
     }
 
+    protected Container.ExecResult executeCommand(String... command) {
+        return ContainerUtils.executeInContainer(container, command);
+    }
+
 }

--- a/testcontainers-common/src/main/java/com/playtika/testcontainer/common/utils/YumPackageInstaller.java
+++ b/testcontainers-common/src/main/java/com/playtika/testcontainer/common/utils/YumPackageInstaller.java
@@ -12,8 +12,8 @@ public class YumPackageInstaller extends PackageInstaller {
 
     @Override
     protected boolean shouldInstall(String packageToInstall) {
-        Container.ExecResult execResult = executeCommandAndCheckExitCode("yum", "list", "installed");
-        return !execResult.getStdout().contains(packageToInstall);
+        Container.ExecResult execResult = executeCommand("rpm", "-q", packageToInstall);
+        return execResult.getExitCode() != 0;
     }
 
     @Override

--- a/testcontainers-common/src/test/java/com/playtika/testcontainer/common/utils/YumPackageInstallerTest.java
+++ b/testcontainers-common/src/test/java/com/playtika/testcontainer/common/utils/YumPackageInstallerTest.java
@@ -1,0 +1,64 @@
+package com.playtika.testcontainer.common.utils;
+
+import com.playtika.testcontainer.common.properties.InstallPackageProperties;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.GenericContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class YumPackageInstallerTest {
+
+    @Test
+    public void shouldInstallReturnsTrueWhenPackageMissing() {
+        InstallPackageProperties properties = new InstallPackageProperties();
+        GenericContainer<?> container = mock(GenericContainer.class);
+
+        TestableYumPackageInstaller installer = new TestableYumPackageInstaller(properties, container);
+        installer.setMockExitCode(1); // Package missing
+
+        assertThat(installer.shouldInstall("missing-package")).isTrue();
+        assertThat(installer.lastCommand).containsExactly("rpm", "-q", "missing-package");
+    }
+
+    @Test
+    public void shouldInstallReturnsFalseWhenPackagePresent() {
+        InstallPackageProperties properties = new InstallPackageProperties();
+        GenericContainer<?> container = mock(GenericContainer.class);
+
+        TestableYumPackageInstaller installer = new TestableYumPackageInstaller(properties, container);
+        installer.setMockExitCode(0); // Package present
+
+        assertThat(installer.shouldInstall("present-package")).isFalse();
+        assertThat(installer.lastCommand).containsExactly("rpm", "-q", "present-package");
+    }
+
+    static class TestableYumPackageInstaller extends YumPackageInstaller {
+        private int mockExitCode;
+        public String[] lastCommand;
+
+        public TestableYumPackageInstaller(InstallPackageProperties properties, GenericContainer<?> container) {
+            super(properties, container);
+        }
+
+        public void setMockExitCode(int code) {
+            this.mockExitCode = code;
+        }
+
+        @Override
+        public boolean shouldInstall(String packageToInstall) {
+             return super.shouldInstall(packageToInstall);
+        }
+
+        @Override
+        protected Container.ExecResult executeCommand(String... command) {
+            this.lastCommand = command;
+            Container.ExecResult result = mock(Container.ExecResult.class);
+            when(result.getExitCode()).thenReturn(mockExitCode);
+            when(result.getStdout()).thenReturn("mock output");
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
Optimize YumPackageInstaller: Use 'rpm -q' instead of 'yum list installed'

This change optimizes the package existence check in `YumPackageInstaller` by replacing the expensive `yum list installed` command with the much faster `rpm -q <package>`.

`yum list installed` iterates over all installed packages, which is an O(N) operation and incurs significant overhead. `rpm -q` performs a direct lookup in the RPM database (O(1) / O(log N)).

Changes:
- Added `executeCommand` to `PackageInstaller` to allow executing commands without enforcing exit code 0 (needed for `rpm -q` on missing packages).
- Updated `YumPackageInstaller.shouldInstall` to use `rpm -q`.
- Added `YumPackageInstallerTest` to verify the logic.

Performance Impact:
- Theoretical complexity reduction from O(N) to O(1).
- Avoids parsing large output from `yum list installed`.
- Improves correctness by avoiding partial string matching issues (e.g. finding "foo-bar" when checking for "foo").