### PR TITLE
docs: Update all README.adoc files to reference the correct bean type ToxiproxyClientProxy instead of the old ToxiproxyContainer.ContainerProxy.

### DIFF
--- a/embedded-aerospike-enterprise/README.adoc
+++ b/embedded-aerospike-enterprise/README.adoc
@@ -45,7 +45,7 @@ purposes only during the Evaluation Period**. See https://github.com/aerospike/a
 * `embedded.aerospike.networkAlias`
 * `embedded.aerospike.internalPort`
 * Bean `AerospikeTestOperations aerospikeTestOperations`
-* Bean `ToxiproxyContainer.ContainerProxy aerospikeContainerProxy`
+* Bean `ToxiproxyClientProxy aerospikeContainerProxy`
 
 ==== Example
 

--- a/embedded-aerospike/README.adoc
+++ b/embedded-aerospike/README.adoc
@@ -37,7 +37,7 @@ ToxiProxy is a great tool for simulating network conditions, meaning that you ca
 * `embedded.aerospike.networkAlias`
 * `embedded.aerospike.internalPort`
 * Bean `AerospikeTestOperations aerospikeTestOperations`
-* Bean `ToxiproxyContainer.ContainerProxy aerospikeContainerProxy`
+* Bean `ToxiproxyClientProxy aerospikeContainerProxy`
 
 ==== Example
 
@@ -92,7 +92,7 @@ public AerospikeClient aerospikeToxicClient(@Value("${embedded.aerospike.toxipro
     String namespace;
 
     @Autowired
-    ToxiproxyContainer.ContainerProxy aerospikeContainerProxy;
+    ToxiproxyClientProxy aerospikeContainerProxy;
 
     @Qualifier("aerospikeToxicClient")
     @Autowired
@@ -150,5 +150,5 @@ To manipulate ToxiProxy inject the following bean into your tests:
 [source,java]
 ----
 @Autowired
-ToxiproxyContainer.ContainerProxy aerospikeContainerProxy;
+ToxiproxyClientProxy aerospikeContainerProxy;
 ----

--- a/embedded-artifactory/README.adoc
+++ b/embedded-artifactory/README.adoc
@@ -34,4 +34,4 @@
 * `embedded.artifactory.staticNetworkAlias`
 * `embedded.artifactory.internalRestApiPort`
 * `embedded.artifactory.internalGeneralPort`
-* Bean `ToxiproxyContainer.ContainerProxy artifactoryContainerProxy`
+* Bean `ToxiproxyClientProxy artifactoryContainerProxy`

--- a/embedded-azurite/README.adoc
+++ b/embedded-azurite/README.adoc
@@ -38,9 +38,9 @@ Account name and account key are hardcoded as of https://github.com/Azure/Azurit
 * `embedded.azurite.toxiproxy.queueStoragePort`
 * `embedded.azurite.toxiproxy.tableStoragePort`
 * `embedded.azurite.networkAlias`
-* Bean `ToxiproxyContainer.ContainerProxy azuriteBlobContainerProxy`
-* Bean `ToxiproxyContainer.ContainerProxy azuriteQueueContainerProxy`
-* Bean `ToxiproxyContainer.ContainerProxy azuriteTableContainerProxy`
+* Bean `ToxiproxyClientProxy azuriteBlobContainerProxy`
+* Bean `ToxiproxyClientProxy azuriteQueueContainerProxy`
+* Bean `ToxiproxyClientProxy azuriteTableContainerProxy`
 ==== Example
 
 Use `com.azure.spring:spring-cloud-azure-starter-storage-blob` (see https://docs.microsoft.com/en-us/azure/developer/java/spring-framework/configure-spring-boot-starter-java-app-with-azure-storage)

--- a/embedded-cassandra/README.adoc
+++ b/embedded-cassandra/README.adoc
@@ -33,7 +33,7 @@
 * `embedded.cassandra.toxiproxy.port`
 * `embedded.cassandra.networkAlias`
 * `embedded.cassandra.internalPort`
-* Bean `ToxiproxyContainer.ContainerProxy cassandraContainerProxy`
+* Bean `ToxiproxyClientProxy cassandraContainerProxy`
 
 ==== Example
 

--- a/embedded-clickhouse/README.adoc
+++ b/embedded-clickhouse/README.adoc
@@ -35,7 +35,7 @@
 * `embedded.clickhouse.toxiproxy.port`
 * `embedded.clickhouse.networkAlias`
 * `embedded.clickhouse.internalPort`
-* Bean `ToxiproxyContainer.ContainerProxy clickhouseContainerProxy`
+* Bean `ToxiproxyClientProxy clickhouseContainerProxy`
 
 ==== Example
 

--- a/embedded-cockroachdb/README.adoc
+++ b/embedded-cockroachdb/README.adoc
@@ -33,4 +33,4 @@
 * `embedded.cockroach.toxiproxy.port`
 * `embedded.cockroach.networkAlias`
 * `embedded.cockroach.internalPort`
-* Bean `ToxiproxyContainer.ContainerProxy cockroachContainerProxy`
+* Bean `ToxiproxyClientProxy cockroachContainerProxy`

--- a/embedded-cockroachdb/src/test/java/com/playtika/testcontainer/cockroach/DisableCockroachDBTest.java
+++ b/embedded-cockroachdb/src/test/java/com/playtika/testcontainer/cockroach/DisableCockroachDBTest.java
@@ -7,7 +7,7 @@ import org.testcontainers.containers.Container;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DisableMariaDBTest {
+public class DisableCockroachDBTest {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(

--- a/embedded-consul/README.adoc
+++ b/embedded-consul/README.adoc
@@ -44,4 +44,4 @@ embedded:
 * `embedded.consul.toxiproxy.port`
 * `embedded.consul.networkAlias`
 * `embedded.consul.internalPort`
-* Bean `ToxiproxyContainer.ContainerProxy consulContainerProxy`
+* Bean `ToxiproxyClientProxy consulContainerProxy`

--- a/embedded-couchbase/README.adoc
+++ b/embedded-couchbase/README.adoc
@@ -35,7 +35,7 @@
 * `embedded.couchbase.toxiproxy.host`
 * `embedded.couchbase.toxiproxy.port`
 * `embedded.couchbase.networkAlias`
-* Bean `ToxiproxyContainer.ContainerProxy couchbaseContainerProxy`
+* Bean `ToxiproxyClientProxy couchbaseContainerProxy`
 
 ==== Notes
 

--- a/embedded-db2/README.adoc
+++ b/embedded-db2/README.adoc
@@ -37,4 +37,4 @@
 * `embedded.db2.toxiproxy.port`
 * `embedded.db2.networkAlias`
 * `embedded.db2.internalPort`
-* Bean `ToxiproxyContainer.ContainerProxy db2ContainerProxy`
+* Bean `ToxiproxyClientProxy db2ContainerProxy`

--- a/embedded-dynamodb/README.adoc
+++ b/embedded-dynamodb/README.adoc
@@ -31,7 +31,7 @@
 * `embedded.dynamodb.toxiproxy.port`
 * `embedded.dynamodb.networkAlias`
 * `embedded.dynamodb.internalPort`
-* Bean `ToxiproxyContainer.ContainerProxy dynamodbContainerProxy`
+* Bean `ToxiproxyClientProxy dynamodbContainerProxy`
 
 
 //TODO: example missing

--- a/embedded-elasticsearch/README.adoc
+++ b/embedded-elasticsearch/README.adoc
@@ -34,7 +34,7 @@
 * `embedded.elasticsearch.networkAlias`
 * `embedded.elasticsearch.internalHttpPort`
 * `embedded.elasticsearch.internalTransportPort`
-* Bean `ToxiproxyContainer.ContainerProxy elasticsearchContainerProxy`
+* Bean `ToxiproxyClientProxy elasticsearchContainerProxy`
 
 
 ==== Example

--- a/embedded-google-pubsub/README.adoc
+++ b/embedded-google-pubsub/README.adoc
@@ -54,11 +54,11 @@ embedded.google.pubsub:
 * `embedded.google.pubsub.toxiproxy.port`
 * `embedded.google.pubsub.networkAlias`
 * `embedded.google.pubsub.internalPort`
-* Bean `ToxiproxyContainer.ContainerProxy googlePubSubContainerProxy`
+* Bean `ToxiproxyClientProxy googlePubSubContainerProxy`
 
 ==== Example
 
-To auto-configure `spring-cloud-gcp-starter-pubsub` use these properties in your test `application.yaml`:
+To auto-configure `spring-cloud-gcp-starter-pubsub` use these properties in your test `application-test.yaml`:
 
 ./src/test/resources/application.yaml
 [source,yaml]

--- a/embedded-google-storage/README.adoc
+++ b/embedded-google-storage/README.adoc
@@ -41,7 +41,7 @@
 * `embedded.google.storage.toxiproxy.port`
 * `embedded.google.storage.networkAlias`
 * `embedded.google.storage.internalPort`
-* Bean `ToxiproxyContainer.ContainerProxy googleStorageContainerProxy`
+* Bean `ToxiproxyClientProxy googleStorageContainerProxy`
 
 ==== Example
 

--- a/embedded-grafana/README.adoc
+++ b/embedded-grafana/README.adoc
@@ -34,4 +34,4 @@
 * `embedded.grafana.toxiproxy.port`
 * `embedded.grafana.networkAlias`
 * `embedded.grafana.internalPort`
-* Bean `ToxiproxyContainer.ContainerProxy grafanaContainerProxy`
+* Bean `ToxiproxyClientProxy grafanaContainerProxy`

--- a/embedded-influxdb/README.adoc
+++ b/embedded-influxdb/README.adoc
@@ -40,12 +40,12 @@
 * `embedded.influxdb.toxiproxy.port`
 * `embedded.influxdb.networkAlias`
 * `embedded.influxdb.internalPort`
-* Bean `ToxiproxyContainer.ContainerProxy influxdbContainerProxy`
+* Bean `ToxiproxyClientProxy influxdbContainerProxy`
 
 ==== Example
 
 There is currently no starter library for using InfluxDB server version 1.x because it uses basic HTTP protocol to communicate.
-You can anyway create your own properties using those values for example in your test `application.yaml`:
+You can anyway create your own properties using those values for example in your test `application-test.yaml`:
 
 ./src/test/resources/application.yaml
 [source,yaml]

--- a/embedded-kafka/README.adoc
+++ b/embedded-kafka/README.adoc
@@ -60,8 +60,8 @@ By default, to your projects `target` folder. You can configure binding using pr
 * `embedded.kafka.networkAlias`
 * `embedded.kafka.internalPort`
 * `embedded.kafka.internalSaslPlaintextPort`
-* Bean `ToxiproxyContainer.ContainerProxy kafkaPlainTextContainerProxy`
-* Bean `ToxiproxyContainer.ContainerProxy kafkaSaslContainerProxy`
+* Bean `ToxiproxyClientProxy kafkaPlainTextContainerProxy`
+* Bean `ToxiproxyClientProxy kafkaSaslContainerProxy`
 
 ==== Using `SASL_PLAINTEXT`
 

--- a/embedded-keycloak/README.adoc
+++ b/embedded-keycloak/README.adoc
@@ -34,7 +34,7 @@
 * `embedded.keycloak.toxiproxy.port`
 * `embedded.keycloak.networkAlias`
 * `embedded.keycloak.internalPort`
-* Bean `ToxiproxyContainer.ContainerProxy keycloakContainerProxy`
+* Bean `ToxiproxyClientProxy keycloakContainerProxy`
 
 ==== Example
 To configure for example the `keycloak-spring-boot-starter` use these properties in your test `application.yaml`:

--- a/embedded-keydb/README.adoc
+++ b/embedded-keydb/README.adoc
@@ -34,6 +34,6 @@
 * `embedded.keydb.toxiproxy.host`
 * `embedded.keydb.toxiproxy.port`
 * `embedded.keydb.networkAlias`
-* Bean `ToxiproxyContainer.ContainerProxy keyDbContainerProxy`
+* Bean `ToxiproxyClientProxy keyDbContainerProxy`
 
 //TODO: example missing

--- a/embedded-localstack/README.adoc
+++ b/embedded-localstack/README.adoc
@@ -37,6 +37,6 @@
 * `embedded.localstack.toxiproxy.port`
 * `embedded.localstack.networkAlias`
 * `embedded.localstack.internalEdgePort`
-* Bean `ToxiproxyContainer.ContainerProxy localstackContainerProxy`
+* Bean `ToxiproxyClientProxy localstackContainerProxy`
 
 // TODO: missing example

--- a/embedded-mailhog/README.adoc
+++ b/embedded-mailhog/README.adoc
@@ -34,7 +34,7 @@
 * `embedded.mailhog.networkAlias`
 * `embedded.mailhog.internalSmtpPort`
 * `embedded.mailhog.internalHttpPort`
-* Bean `ToxiproxyContainer.ContainerProxy mailhogSmtpContainerProxy`
+* Bean `ToxiproxyClientProxy mailhogSmtpContainerProxy`
 
 ==== Example (Spring Boot)
 

--- a/embedded-mariadb/README.adoc
+++ b/embedded-mariadb/README.adoc
@@ -37,7 +37,7 @@
 * `embedded.mariadb.toxiproxy.port`
 * `embedded.mariadb.networkAlias`
 * `embedded.mariadb.internalPort`
-* Bean `ToxiproxyContainer.ContainerProxy mariadbContainerProxy`
+* Bean `ToxiproxyClientProxy mariadbContainerProxy`
 
 
 //TODO: example missing

--- a/embedded-memsql/README.adoc
+++ b/embedded-memsql/README.adoc
@@ -38,7 +38,7 @@ Singlestore docker image does not support ARM
 * `embedded.memsql.toxiproxy.port`
 * `embedded.memsql.networkAlias`
 * `embedded.memsql.internalPort`
-* Bean `ToxiproxyContainer.ContainerProxy memsqlContainerProxy`
+* Bean `ToxiproxyClientProxy memsqlContainerProxy`
 
 ==== Notes
 

--- a/embedded-minio/README.adoc
+++ b/embedded-minio/README.adoc
@@ -39,6 +39,6 @@
 * `embedded.minio.networkAlias`
 * `embedded.minio.internalPort`
 * `embedded.minio.internalConsolePort`
-* Bean `ToxiproxyContainer.ContainerProxy minioContainerProxy`
+* Bean `ToxiproxyClientProxy minioContainerProxy`
 
 //TODO: example missing

--- a/embedded-mongodb/README.adoc
+++ b/embedded-mongodb/README.adoc
@@ -39,7 +39,7 @@
 * `embedded.mongodb.toxiproxy.port`
 * `embedded.mongodb.networkAlias`
 * `embedded.mongodb.internalPort`
-* Bean `ToxiproxyContainer.ContainerProxy mongodbContainerProxy`
+* Bean `ToxiproxyClientProxy mongodbContainerProxy`
 
 ==== Example
 

--- a/embedded-mssqlserver/README.adoc
+++ b/embedded-mssqlserver/README.adoc
@@ -39,4 +39,4 @@ do not allow to set those parameters.
 * `embedded.mssqlserver.toxiproxy.port`
 * `embedded.mssqlserver.networkAlias`
 * `embedded.mssqlserver.internalPort`
-* Bean `ToxiproxyContainer.ContainerProxy mssqlserverContainerProxy`
+* Bean `ToxiproxyClientProxy mssqlserverContainerProxy`

--- a/embedded-mysql/README.adoc
+++ b/embedded-mysql/README.adoc
@@ -35,6 +35,6 @@
 * `embedded.mysql.toxiproxy.port`
 * `embedded.mysql.networkAlias`
 * `embedded.mysql.internalPort`
-* Bean `ToxiproxyContainer.ContainerProxy mysqlContainerProxy`
+* Bean `ToxiproxyClientProxy mysqlContainerProxy`
 
 // TODO: missing example

--- a/embedded-native-kafka/README.adoc
+++ b/embedded-native-kafka/README.adoc
@@ -41,6 +41,55 @@ By default, to your projects `target` folder. You can configure binding using pr
 * `embedded.kafka.host`
 * `embedded.kafka.port`
 
+==== Toxiproxy Support
+
+The module supports https://github.com/Shopify/toxiproxy[Toxiproxy] for simulating network conditions.
+
+To enable Toxiproxy for native Kafka:
+
+[source,properties]
+----
+embedded.toxiproxy.proxies.kafka.enabled=true
+----
+
+This will create a proxy between your test and the Kafka container, allowing you to simulate various network conditions.
+
+===== Produces (when Toxiproxy is enabled)
+
+* `embedded.kafka.toxiproxy.bootstrapServers` - Proxied bootstrap servers
+* `embedded.kafka.toxiproxy.brokerList` - Same as bootstrapServers for compatibility
+* `embedded.kafka.toxiproxy.host` - Toxiproxy host
+* `embedded.kafka.toxiproxy.port` - Toxiproxy port  
+* `embedded.kafka.toxiproxy.proxyName` - Name of the proxy for programmatic access
+
+===== Example with Toxiproxy
+
+[source,java]
+----
+@SpringBootTest
+@TestPropertySource(properties = {
+    "embedded.toxiproxy.proxies.kafka.enabled=true"
+})
+class NativeKafkaWithToxiproxyTest {
+    
+    @Value("${embedded.kafka.toxiproxy.bootstrapServers}")
+    String proxiedBootstrapServers;
+    
+    @Autowired(required = false)
+    @Qualifier("nativeKafkaContainerProxy")
+    ToxiproxyClientProxy proxy;
+    
+    @Test
+    void testWithLatency() {
+        // Add 500ms latency
+        proxy.toxics()
+            .latency("latency", ToxicDirection.DOWNSTREAM, 500);
+        
+        // Test Kafka with network latency
+    }
+}
+----
+
 ==== Example configuration
 
 .`embedded-native-kafka` configuration (via `bootstrap.properties`)

--- a/embedded-nats/README.adoc
+++ b/embedded-nats/README.adoc
@@ -33,7 +33,7 @@
 * `embedded.nats.internalClientPort`
 * `embedded.nats.internalHttpMonitorPort`
 * `embedded.nats.internalRouteConnectionsPort`
-* Bean `ToxiproxyContainer.ContainerProxy natsContainerProxy`
+* Bean `ToxiproxyClientProxy natsContainerProxy`
 
 ==== Notes
 
@@ -57,7 +57,7 @@ embedded.toxiproxy.proxies.nats.enabled=true
 [source,java]
 ----
 @Autowired
-ToxiproxyContainer.ContainerProxy natsContainerProxy;
+ToxiproxyClientProxy natsContainerProxy;
 ----
 
 

--- a/embedded-neo4j/README.adoc
+++ b/embedded-neo4j/README.adoc
@@ -36,6 +36,6 @@
 * `embedded.neo4j.internalHttpsPort`
 * `embedded.neo4j.internalHttpPort`
 * `embedded.neo4j.internalBoltPort`
-* Bean `ToxiproxyContainer.ContainerProxy neo4jContainerProxy`
+* Bean `ToxiproxyClientProxy neo4jContainerProxy`
 
 //TODO: example missing

--- a/embedded-opensearch/README.adoc
+++ b/embedded-opensearch/README.adoc
@@ -38,7 +38,7 @@
 * `embedded.opensearch.networkAlias`
 * `embedded.opensearch.internalHttpPort`
 * `embedded.opensearch.internalTransportPort`
-* Bean `ToxiproxyContainer.ContainerProxy opensearchContainerProxy`
+* Bean `ToxiproxyClientProxy opensearchContainerProxy`
 
 
 ==== Example

--- a/embedded-oracle-xe/README.adoc
+++ b/embedded-oracle-xe/README.adoc
@@ -34,6 +34,6 @@
 * `embedded.oracle.toxiproxy.port`
 * `embedded.oracle.networkAlias`
 * `embedded.oracle.internalPort`
-* Bean `ToxiproxyContainer.ContainerProxy oracleContainerProxy`
+* Bean `ToxiproxyClientProxy oracleContainerProxy`
 
 // TODO: missing example

--- a/embedded-postgresql/README.adoc
+++ b/embedded-postgresql/README.adoc
@@ -39,7 +39,7 @@
 * `embedded.postgresql.toxiproxy.port`
 * `embedded.postgresql.networkAlias`
 * `embedded.postgresql.internalPort`
-* Bean `ToxiproxyContainer.ContainerProxy postgresqlContainerProxy`
+* Bean `ToxiproxyClientProxy postgresqlContainerProxy`
 
 ==== Example (Spring Boot)
 

--- a/embedded-prometheus/README.adoc
+++ b/embedded-prometheus/README.adoc
@@ -31,4 +31,4 @@
 * `embedded.prometheus.toxiproxy.port`
 * `embedded.prometheus.staticNetworkAlias`
 * `embedded.prometheus.internalPort`
-* Bean `ToxiproxyContainer.ContainerProxy prometheusContainerProxy`
+* Bean `ToxiproxyClientProxy prometheusContainerProxy`

--- a/embedded-pulsar/README.adoc
+++ b/embedded-pulsar/README.adoc
@@ -28,7 +28,7 @@
 * `embedded.pulsar.toxiproxy.port`
 * `embedded.pulsar.networkAlias`
 * `embedded.pulsar.internalBrokerPort`
-* Bean `ToxiproxyContainer.ContainerProxy pulsarContainerProxy`
+* Bean `ToxiproxyClientProxy pulsarContainerProxy`
 
 ==== Example
 

--- a/embedded-rabbitmq/README.adoc
+++ b/embedded-rabbitmq/README.adoc
@@ -39,7 +39,7 @@
 * `embedded.rabbitmq.networkAlias`
 * `embedded.rabbitmq.internalPort`
 * `embedded.rabbitmq.internalHttpPort`
-* Bean `ToxiproxyContainer.ContainerProxy rabbitmqContainerProxy`
+* Bean `ToxiproxyClientProxy rabbitmqContainerProxy`
 * `embedded.rabbitmq.additionalPorts.x` (where `x` is the port from the container, e.g. `5552`; the value is the mapped port within the Docker container)
 
 ==== Example

--- a/embedded-redis/README.adoc
+++ b/embedded-redis/README.adoc
@@ -34,6 +34,6 @@
 * `embedded.redis.toxiproxy.host`
 * `embedded.redis.toxiproxy.port`
 * `embedded.redis.networkAlias`
-* Bean `ToxiproxyContainer.ContainerProxy redisContainerProxy`
+* Bean `ToxiproxyClientProxy redisContainerProxy`
 
 //TODO: example missing

--- a/embedded-selenium/README.adoc
+++ b/embedded-selenium/README.adoc
@@ -35,7 +35,7 @@
 * `embedded.selenium.toxiproxy.host`
 * `embedded.selenium.toxiproxy.port`
 * `embedded.selenium.networkAlias`
-* Bean `ToxiproxyContainer.ContainerProxy seleniumContainerProxy`
+* Bean `ToxiproxyClientProxy seleniumContainerProxy`
 
 ==== Example
 

--- a/embedded-solr/README.adoc
+++ b/embedded-solr/README.adoc
@@ -29,4 +29,4 @@
 * `embedded.solr.toxiproxy.port`
 * `embedded.solr.networkAlias`
 * `embedded.solr.internalPort`
-* Bean `ToxiproxyContainer.ContainerProxy solrContainerProxy`
+* Bean `ToxiproxyClientProxy solrContainerProxy`

--- a/embedded-spicedb/README.adoc
+++ b/embedded-spicedb/README.adoc
@@ -29,4 +29,4 @@
 * `embedded.spicedb.toxiproxy.host`
 * `embedded.spicedb.toxiproxy.port`
 * `embedded.spicedb.networkAlias`
-* Bean `ToxiproxyContainer.ContainerProxy spicedbContainerProxy`
+* Bean `ToxiproxyClientProxy spicedbContainerProxy`

--- a/embedded-vault/README.adoc
+++ b/embedded-vault/README.adoc
@@ -37,7 +37,7 @@
 * `embedded.vault.toxiproxy.port`
 * `embedded.vault.networkAlias`
 * `embedded.vault.internalPort`
-* Bean `ToxiproxyContainer.ContainerProxy vaultContainerProxy`
+* Bean `ToxiproxyClientProxy vaultContainerProxy`
 
 ==== Example
 

--- a/embedded-vertica/README.adoc
+++ b/embedded-vertica/README.adoc
@@ -33,7 +33,7 @@
 * `embedded.vertica.toxiproxy.port`
 * `embedded.vertica.networkAlias`
 * `embedded.vertica.internalPort`
-* Bean `ToxiproxyContainer.ContainerProxy verticaContainerProxy`
+* Bean `ToxiproxyClientProxy verticaContainerProxy`
 
 ==== Notes
 

--- a/embedded-victoriametrics/README.adoc
+++ b/embedded-victoriametrics/README.adoc
@@ -41,5 +41,5 @@ To manipulate ToxiProxy inject the following bean into your tests:
 [source,java]
 ----
 @Autowired
-ToxiproxyContainer.ContainerProxy victoriaMetricsContainerProxy;
+ToxiproxyClientProxy victoriaMetricsContainerProxy;
 ----


### PR DESCRIPTION
Cherry-picked from #2398.