### PR TITLE
[feature] Add lettuce driver for redis #2507

### DIFF
--- a/embedded-redis/README.adoc
+++ b/embedded-redis/README.adoc
@@ -24,6 +24,21 @@
 * `embedded.redis.requirepass` `(true|false, default is true)`
 * `embedded.toxiproxy.proxies.redis.enabled` Enables both creation of the container with ToxiProxy TCP proxy and a proxy to the `embedded-redis` container.
 
+==== Redis Client Drivers
+
+The embedded-redis module supports both Jedis and Lettuce Redis client drivers:
+
+* **Jedis**: Synchronous Redis client (default when Jedis is on classpath)
+* **Lettuce**: Asynchronous and reactive Redis client, supports cluster mode and reactive operations
+
+Both drivers are optional dependencies. Spring Boot will auto-configure the appropriate connection factory based on which drivers are available on the classpath. To explicitly use Lettuce, configure:
+
+[source,properties]
+----
+spring.data.redis.client-type=lettuce
+----
+
+The module automatically ensures that `LettuceConnectionFactory` and `JedisConnectionFactory` beans depend on the embedded Redis container, ensuring proper startup order.
 
 ==== Produces
 

--- a/embedded-redis/pom.xml
+++ b/embedded-redis/pom.xml
@@ -42,5 +42,22 @@
             <version>${jedis.version}</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.lettuce</groupId>
+            <artifactId>lettuce-core</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 </project>

--- a/embedded-redis/src/main/java/com/playtika/testcontainer/redis/EmbeddedRedisDependenciesAutoConfiguration.java
+++ b/embedded-redis/src/main/java/com/playtika/testcontainer/redis/EmbeddedRedisDependenciesAutoConfiguration.java
@@ -11,6 +11,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import redis.clients.jedis.Jedis;
 
@@ -47,6 +48,15 @@ public class EmbeddedRedisDependenciesAutoConfiguration {
         @Bean
         public static BeanFactoryPostProcessor jedisDependencyPostProcessor() {
             return new DependsOnPostProcessor(Jedis.class, new String[]{BEAN_NAME_EMBEDDED_REDIS});
+        }
+    }
+
+    @Configuration
+    @ConditionalOnClass(LettuceConnectionFactory.class)
+    public static class LettuceDependencyContext {
+        @Bean
+        public static BeanFactoryPostProcessor lettuceConnectionFactoryDependencyPostProcessor() {
+            return new DependsOnPostProcessor(LettuceConnectionFactory.class, new String[]{BEAN_NAME_EMBEDDED_REDIS});
         }
     }
 }

--- a/embedded-redis/src/test/java/com/playtika/testcontainer/redis/clustered/ClusteredEmbeddedRedisLettuceTest.java
+++ b/embedded-redis/src/test/java/com/playtika/testcontainer/redis/clustered/ClusteredEmbeddedRedisLettuceTest.java
@@ -1,0 +1,80 @@
+package com.playtika.testcontainer.redis.clustered;
+
+import com.playtika.testcontainer.redis.BaseEmbeddedRedisTest;
+import com.playtika.testcontainer.redis.RedisProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.BeanFactoryUtils;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisPassword;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+import java.util.Collections;
+
+import static com.playtika.testcontainer.redis.RedisProperties.BEAN_NAME_EMBEDDED_REDIS;
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@SpringBootTest(
+        classes = ClusteredEmbeddedRedisLettuceTest.TestConfiguration.class,
+        properties = {
+                "embedded.redis.clustered=true"
+        }
+)
+public class ClusteredEmbeddedRedisLettuceTest extends BaseEmbeddedRedisTest {
+
+    @Test
+    public void shouldSetupDependsOnForLettuceConnectionFactory() throws Exception {
+        String[] beanNamesForType = BeanFactoryUtils.beanNamesForTypeIncludingAncestors(beanFactory, RedisConnectionFactory.class);
+        assertThat(beanNamesForType)
+                .as("RedisConnectionFactory should be present")
+                .hasSize(1)
+                .contains("connectionFactory");
+        asList(beanNamesForType).forEach(this::hasDependsOn);
+
+        beanNamesForType = BeanFactoryUtils.beanNamesForTypeIncludingAncestors(beanFactory, org.springframework.data.redis.core.RedisTemplate.class);
+        assertThat(beanNamesForType)
+                .as("redisTemplates should be present")
+                .hasSize(2)
+                .contains("redisTemplate", "stringRedisTemplate");
+        asList(beanNamesForType).forEach(this::hasDependsOn);
+    }
+
+    @Test
+    public void shouldUseLettuceConnectionFactory() {
+        RedisConnectionFactory connectionFactory = beanFactory.getBean(RedisConnectionFactory.class);
+        assertThat(connectionFactory)
+                .as("Should use LettuceConnectionFactory")
+                .isInstanceOf(LettuceConnectionFactory.class);
+    }
+
+    private void hasDependsOn(String beanName) {
+        assertThat(beanFactory.getBeanDefinition(beanName).getDependsOn())
+                .isNotNull()
+                .isNotEmpty()
+                .contains(BEAN_NAME_EMBEDDED_REDIS);
+    }
+
+    @EnableAutoConfiguration
+    @Configuration
+    static class TestConfiguration {
+
+        @Bean
+        public RedisConnectionFactory connectionFactory(RedisProperties redisProperties) {
+            log.info(format("Connecting to Redis Cluster node with Lettuce: %s:%s", redisProperties.getHost(), redisProperties.getPort()));
+            RedisClusterConfiguration redisConfiguration = new RedisClusterConfiguration(
+                    Collections.singletonList(format("%s:%s", redisProperties.getHost(), redisProperties.getPort())));
+            if (redisProperties.isRequirepass()) {
+                redisConfiguration.setPassword(RedisPassword.of(redisProperties.getPassword()));
+            }
+            return new LettuceConnectionFactory(redisConfiguration);
+        }
+    }
+}

--- a/embedded-redis/src/test/java/com/playtika/testcontainer/redis/clustered/ClusteredEmbeddedRedisLettuceTest.java
+++ b/embedded-redis/src/test/java/com/playtika/testcontainer/redis/clustered/ClusteredEmbeddedRedisLettuceTest.java
@@ -28,10 +28,10 @@ import static org.assertj.core.api.Assertions.assertThat;
                 "embedded.redis.clustered=true"
         }
 )
-public class ClusteredEmbeddedRedisLettuceTest extends BaseEmbeddedRedisTest {
+class ClusteredEmbeddedRedisLettuceTest extends BaseEmbeddedRedisTest {
 
     @Test
-    public void shouldSetupDependsOnForLettuceConnectionFactory() throws Exception {
+    void shouldSetupDependsOnForLettuceConnectionFactory() throws Exception {
         String[] beanNamesForType = BeanFactoryUtils.beanNamesForTypeIncludingAncestors(beanFactory, RedisConnectionFactory.class);
         assertThat(beanNamesForType)
                 .as("RedisConnectionFactory should be present")
@@ -48,7 +48,7 @@ public class ClusteredEmbeddedRedisLettuceTest extends BaseEmbeddedRedisTest {
     }
 
     @Test
-    public void shouldUseLettuceConnectionFactory() {
+    void shouldUseLettuceConnectionFactory() {
         RedisConnectionFactory connectionFactory = beanFactory.getBean(RedisConnectionFactory.class);
         assertThat(connectionFactory)
                 .as("Should use LettuceConnectionFactory")
@@ -67,7 +67,7 @@ public class ClusteredEmbeddedRedisLettuceTest extends BaseEmbeddedRedisTest {
     static class TestConfiguration {
 
         @Bean
-        public RedisConnectionFactory connectionFactory(RedisProperties redisProperties) {
+        RedisConnectionFactory connectionFactory(RedisProperties redisProperties) {
             log.info(format("Connecting to Redis Cluster node with Lettuce: %s:%s", redisProperties.getHost(), redisProperties.getPort()));
             RedisClusterConfiguration redisConfiguration = new RedisClusterConfiguration(
                     Collections.singletonList(format("%s:%s", redisProperties.getHost(), redisProperties.getPort())));

--- a/embedded-redis/src/test/java/com/playtika/testcontainer/redis/standalone/StandaloneEmbeddedRedisLettuceTest.java
+++ b/embedded-redis/src/test/java/com/playtika/testcontainer/redis/standalone/StandaloneEmbeddedRedisLettuceTest.java
@@ -1,0 +1,75 @@
+package com.playtika.testcontainer.redis.standalone;
+
+import com.playtika.testcontainer.redis.BaseEmbeddedRedisTest;
+import com.playtika.testcontainer.redis.RedisProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.BeanFactoryUtils;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisPassword;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import static com.playtika.testcontainer.redis.RedisProperties.BEAN_NAME_EMBEDDED_REDIS;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+@SpringBootTest(
+        classes = StandaloneEmbeddedRedisLettuceTest.TestConfiguration.class
+)
+public class StandaloneEmbeddedRedisLettuceTest extends BaseEmbeddedRedisTest {
+
+    @Test
+    public void shouldSetupDependsOnForLettuceConnectionFactory() throws Exception {
+        String[] beanNamesForType = BeanFactoryUtils.beanNamesForTypeIncludingAncestors(beanFactory, RedisConnectionFactory.class);
+        assertThat(beanNamesForType)
+                .as("RedisConnectionFactory should be present")
+                .hasSize(1)
+                .contains("redisConnectionFactory");
+        asList(beanNamesForType).forEach(this::hasDependsOn);
+
+        beanNamesForType = BeanFactoryUtils.beanNamesForTypeIncludingAncestors(beanFactory, RedisTemplate.class);
+        assertThat(beanNamesForType)
+                .as("redisTemplates should be present")
+                .hasSize(2)
+                .contains("redisTemplate", "stringRedisTemplate");
+        asList(beanNamesForType).forEach(this::hasDependsOn);
+    }
+
+    @Test
+    public void shouldUseLettuceConnectionFactory() {
+        RedisConnectionFactory connectionFactory = beanFactory.getBean(RedisConnectionFactory.class);
+        assertThat(connectionFactory)
+                .as("Should use LettuceConnectionFactory")
+                .isInstanceOf(LettuceConnectionFactory.class);
+    }
+
+    private void hasDependsOn(String beanName) {
+        assertThat(beanFactory.getBeanDefinition(beanName).getDependsOn())
+                .isNotNull()
+                .isNotEmpty()
+                .contains(BEAN_NAME_EMBEDDED_REDIS);
+    }
+
+    @EnableAutoConfiguration
+    @Configuration
+    static class TestConfiguration {
+
+        @Bean
+        public RedisConnectionFactory redisConnectionFactory(RedisProperties redisProperties) {
+            log.info("Connecting to Redis with Lettuce: {}:{}", redisProperties.getHost(), redisProperties.getPort());
+            RedisStandaloneConfiguration redisConfiguration = new RedisStandaloneConfiguration(
+                    redisProperties.getHost(), redisProperties.getPort());
+            if (redisProperties.isRequirepass()) {
+                redisConfiguration.setPassword(RedisPassword.of(redisProperties.getPassword()));
+            }
+            return new LettuceConnectionFactory(redisConfiguration);
+        }
+    }
+}

--- a/embedded-redis/src/test/resources/application-lettuce.properties
+++ b/embedded-redis/src/test/resources/application-lettuce.properties
@@ -1,0 +1,5 @@
+spring.data.redis.host=${embedded.redis.host}
+spring.data.redis.port=${embedded.redis.port}
+spring.data.redis.client-type=lettuce
+spring.data.redis.timeout=2500
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Lettuce Redis client with classpath-based automatic selection and an option to force Lettuce via configuration.

* **Documentation**
  * Documented supported Redis clients (Jedis and Lettuce), explicit client selection, and startup ordering considerations.

* **Tests**
  * Added integration tests and test properties validating Lettuce wiring and embedded Redis startup ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->