### PR TITLE
housekeeping: Use RedisContainer from testcontainers-redis

### DIFF
--- a/embedded-keydb/pom.xml
+++ b/embedded-keydb/pom.xml
@@ -22,6 +22,10 @@
             <groupId>com.playtika.testcontainers</groupId>
             <artifactId>embedded-toxiproxy</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.redis</groupId>
+            <artifactId>testcontainers-redis</artifactId>
+        </dependency>
 
         <!-- using Redis libraries as KeyDB is compatible with Redis API -->
         <dependency>

--- a/embedded-keydb/src/main/java/com/playtika/testcontainer/keydb/EmbeddedKeyDbBootstrapConfiguration.java
+++ b/embedded-keydb/src/main/java/com/playtika/testcontainer/keydb/EmbeddedKeyDbBootstrapConfiguration.java
@@ -8,6 +8,7 @@ import com.playtika.testcontainer.keydb.wait.KeyDbStatusCheck;
 import com.playtika.testcontainer.toxiproxy.ToxiproxyClientProxy;
 import com.playtika.testcontainer.toxiproxy.ToxiproxyHelper;
 import com.playtika.testcontainer.toxiproxy.condition.ConditionalOnToxiProxyEnabled;
+import com.redis.testcontainers.RedisContainer;
 import eu.rekawek.toxiproxy.ToxiproxyClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +22,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.io.ResourceLoader;
-import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
@@ -86,14 +86,14 @@ public class EmbeddedKeyDbBootstrapConfiguration {
   }
 
   @Bean(name = BEAN_NAME_EMBEDDED_KEYDB, destroyMethod = "stop")
-  public GenericContainer<?> keydb(ConfigurableEnvironment environment,
+  public RedisContainer keydb(ConfigurableEnvironment environment,
                                    @Qualifier(KEYDB_WAIT_STRATEGY_BEAN_NAME) WaitStrategy keydbStartupCheckStrategy,
                                    Optional<Network> network) throws Exception {
 
     // CLUSTER SLOTS command returns IP:port for each node, so ports outside and inside
     // container must be the same
-    GenericContainer<?> keydb =
-      new FixedHostPortGenericContainer(ContainerUtils.getDockerImageName(properties).asCanonicalNameString())
+    RedisContainer keydb =
+      new KeyDbContainerWithExposedPort(ContainerUtils.getDockerImageName(properties).asCanonicalNameString())
         .withFixedExposedPort(properties.getPort(), properties.getPort())
         .withExposedPorts(properties.getPort())
         .withEnv("KEYDB_USER", properties.getUser())
@@ -104,7 +104,7 @@ public class EmbeddedKeyDbBootstrapConfiguration {
         .waitingFor(keydbStartupCheckStrategy)
         .withNetworkAliases(KEYDB_NETWORK_ALIAS);
     network.ifPresent(keydb::withNetwork);
-    keydb = configureCommonsAndStart(keydb, properties, log);
+    keydb = (RedisContainer) configureCommonsAndStart(keydb, properties, log);
     Map<String, Object> keydbEnv = registerKeyDbEnvironment(environment, keydb, properties, properties.getPort());
     log.info("Started KeyDb cluster. Connection details: {}", keydbEnv);
     return keydb;
@@ -124,4 +124,15 @@ public class EmbeddedKeyDbBootstrapConfiguration {
       .replace("{{busPort}}", String.valueOf(properties.getPort() + 10000)));
   }
 
+  private static class KeyDbContainerWithExposedPort extends RedisContainer {
+    public KeyDbContainerWithExposedPort(String dockerImageName) {
+      super(dockerImageName);
+    }
+
+    public RedisContainer withFixedExposedPort(int hostPort, int containerPort) {
+      super.addFixedExposedPort(hostPort, containerPort);
+
+      return self();
+    }
+  }
 }

--- a/embedded-redis/pom.xml
+++ b/embedded-redis/pom.xml
@@ -28,6 +28,10 @@
             <artifactId>embedded-toxiproxy</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.redis</groupId>
+            <artifactId>testcontainers-redis</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-data-redis</artifactId>
             <optional>true</optional>

--- a/embedded-redis/src/main/java/com/playtika/testcontainer/redis/EmbeddedRedisBootstrapConfiguration.java
+++ b/embedded-redis/src/main/java/com/playtika/testcontainer/redis/EmbeddedRedisBootstrapConfiguration.java
@@ -8,6 +8,7 @@ import com.playtika.testcontainer.redis.wait.RedisStatusCheck;
 import com.playtika.testcontainer.toxiproxy.ToxiproxyClientProxy;
 import com.playtika.testcontainer.toxiproxy.ToxiproxyHelper;
 import com.playtika.testcontainer.toxiproxy.condition.ConditionalOnToxiProxyEnabled;
+import com.redis.testcontainers.RedisContainer;
 import eu.rekawek.toxiproxy.ToxiproxyClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,7 +22,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.io.ResourceLoader;
-import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
@@ -86,14 +86,14 @@ public class EmbeddedRedisBootstrapConfiguration {
     }
 
     @Bean(name = BEAN_NAME_EMBEDDED_REDIS, destroyMethod = "stop")
-    public GenericContainer<?> redis(ConfigurableEnvironment environment,
+    public RedisContainer redis(ConfigurableEnvironment environment,
                                      @Qualifier(REDIS_WAIT_STRATEGY_BEAN_NAME) WaitStrategy redisStartupCheckStrategy,
                                      Optional<Network> network) throws Exception {
 
         // CLUSTER SLOTS command returns IP:port for each node, so ports outside and inside
         // container must be the same
-        GenericContainer<?> redis =
-                new FixedHostPortGenericContainer(ContainerUtils.getDockerImageName(properties).asCanonicalNameString())
+        RedisContainer redis =
+            new RedisContainerWithExposedPort(ContainerUtils.getDockerImageName(properties).asCanonicalNameString())
                         .withFixedExposedPort(properties.getPort(), properties.getPort())
                         .withExposedPorts(properties.getPort())
                         .withEnv("REDIS_USER", properties.getUser())
@@ -104,7 +104,7 @@ public class EmbeddedRedisBootstrapConfiguration {
                         .waitingFor(redisStartupCheckStrategy)
                         .withNetworkAliases(REDIS_NETWORK_ALIAS);
         network.ifPresent(redis::withNetwork);
-        redis = configureCommonsAndStart(redis, properties, log);
+        redis = (RedisContainer) configureCommonsAndStart(redis, properties, log);
         Map<String, Object> redisEnv = registerRedisEnvironment(environment, redis, properties, properties.getPort());
         log.info("Started Redis cluster. Connection details: {}", redisEnv);
         return redis;
@@ -122,5 +122,17 @@ public class EmbeddedRedisBootstrapConfiguration {
         return FileUtils.resolveTemplateAsPath(resourceLoader, "nodes.conf", content -> content
                 .replace("{{port}}", String.valueOf(properties.getPort()))
                 .replace("{{busPort}}", String.valueOf(properties.getPort() + 10000)));
+    }
+
+    private static class RedisContainerWithExposedPort extends RedisContainer {
+        public RedisContainerWithExposedPort(String dockerImageName) {
+            super(dockerImageName);
+        }
+
+        public RedisContainer withFixedExposedPort(int hostPort, int containerPort) {
+            super.addFixedExposedPort(hostPort, containerPort);
+
+            return self();
+        }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added testcontainers-redis to KeyDB and Redis modules to improve container test/runtime support.
* **Refactor**
  * Replaced generic container implementations with specialized RedisContainer-based wrappers to improve fixed-port mapping, startup reliability, and stability for tests and local development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->