### PR TITLE
Add Renovate properties manager and update Aerospike Enterprise image

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,10 +27,20 @@
       "versioningTemplate": "docker"
     },
     {
-      "description": "Process embedded docker images in properties and adoc",
+      "description": "Process # renovate comments in properties files",
       "customType": "regex",
       "fileMatch": [
-        "\\.properties$",
+        "\\.properties$"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>[a-zA-Z0-9-]+).*?\\r?\\n\\s*[\\w.-]+\\s*=\\s*(?<depName>[^:\\s]+):?(?<currentValue>[\\w.-]*)"
+      ],
+      "versioningTemplate": "docker"
+    },
+    {
+      "description": "Process embedded docker images in adoc",
+      "customType": "regex",
+      "fileMatch": [
         "\\.adoc$"
       ],
       "matchStrings": [

--- a/.github/renovate/renovate.json
+++ b/.github/renovate/renovate.json
@@ -38,6 +38,17 @@
       "versioningTemplate": "docker"
     },
     {
+      "description": "Process # renovate comments in properties files",
+      "fileMatch": [
+        "^.*\\.properties"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>[a-zA-Z0-9-]+).*?\\r?\\n\\s*[\\w.-]+\\s*=\\s*(?<depName>[^:\\s]+):?(?<currentValue>[\\w.-]*)"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
+    },
+    {
       "description": "Process update properties for docker images",
       "fileMatch": [
         "^.*\\.properties"
@@ -70,6 +81,5 @@
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker"
     }
-
   ]
 }

--- a/embedded-aerospike-enterprise/src/main/resources/embedded-enterprise-aerospike.properties
+++ b/embedded-aerospike-enterprise/src/main/resources/embedded-enterprise-aerospike.properties
@@ -1,3 +1,3 @@
 # Please don`t remove this comment.
 # renovate: datasource=docker
-embedded.aerospike.dockerImage=aerospike/aerospike-server-enterprise:8.1.2.0
+embedded.aerospike.dockerImage=aerospike/aerospike-server-enterprise:8.1.2.1


### PR DESCRIPTION
### Motivation
- Renovate was updating README docs but not the property-backed default image because `# renovate: datasource=docker` comments in `.properties` were not processed.
- Keep the self-hosted Renovate config in sync so automated docker-image updates cover property files as well as docs.

### Description
- Add a Renovate regex custom manager to `.github/renovate.json` that parses `# renovate: datasource=docker` comments in `.properties` files and extracts `depName`/`currentValue` for Docker image updates.
- Mirror the same properties-file manager into the self-hosted config at `.github/renovate/renovate.json` and narrow the adoc manager to only `.adoc` files.
- Manually update the Aerospike Enterprise default image in `embedded-aerospike-enterprise/src/main/resources/embedded-enterprise-aerospike.properties` from `aerospike/aerospike-server-enterprise:8.1.2.0` to `aerospike/aerospike-server-enterprise:8.1.2.1`, preserving the existing comment and `renovate:` marker.

### Testing
- `node` JSON/regex validation of `.github/renovate.json` and `.github/renovate/renovate.json` with the properties regex succeeded.
- `git diff --check` returned clean results and was used to validate the diff formatting.
- `./mvnw -Dgib.disable=true -pl embedded-aerospike-enterprise -am -DskipTests compile` ran successfully and the `embedded-aerospike-enterprise` module compiled.
- `./mvnw -pl embedded-aerospike-enterprise -am -DskipTests compile` (without disabling gitflow-incremental-builder) failed in this environment due to a missing `origin` remote required by GIB, so the successful compile used `-Dgib.disable=true`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1974ace870832782495600361eede4)