### PR TITLE
Make Pulsar HTTP metrics test resilient to endpoint variations

### DIFF
--- a/embedded-pulsar/README.adoc
+++ b/embedded-pulsar/README.adoc
@@ -15,7 +15,7 @@
 ==== Consumes (via `bootstrap.properties`)
 
 * `embedded.pulsar.enabled` `(true|false, default is true)`
-* `embedded.pulsar.docker-image` `(default is 'apachepulsar/pulsar:4.1.3')`
+* `embedded.pulsar.docker-image` `(default is 'apachepulsar/pulsar:4.2.1')`
 ** Image versions on https://hub.docker.com/r/apachepulsar/pulsar/tags[dockerhub]
 * `embedded.toxiproxy.proxies.pulsar.enabled` Enables both creation of the container with ToxiProxy TCP proxy and a proxy to the `embedded-pulsar` container.
 

--- a/embedded-pulsar/src/main/java/com/playtika/testcontainer/pulsar/PulsarProperties.java
+++ b/embedded-pulsar/src/main/java/com/playtika/testcontainer/pulsar/PulsarProperties.java
@@ -18,6 +18,6 @@ public class PulsarProperties extends CommonContainerProperties {
     public String getDefaultDockerImage() {
         // Please don`t remove this comment.
         // renovate: datasource=docker
-        return "apachepulsar/pulsar:4.1.3";
+        return "apachepulsar/pulsar:4.2.1";
     }
 }

--- a/embedded-pulsar/src/test/java/com/playtika/testcontainer/pulsar/EmbeddedPulsarHttpServiceTest.java
+++ b/embedded-pulsar/src/test/java/com/playtika/testcontainer/pulsar/EmbeddedPulsarHttpServiceTest.java
@@ -4,15 +4,20 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatusCode;
 
 import java.net.URI;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class EmbeddedPulsarHttpServiceTest extends AbstractEmbeddedPulsarTest {
 
-    private static final String METRICS_PATH = "/admin/broker-stats/metrics";
+    private static final List<String> METRICS_PATHS = List.of(
+            "/metrics",
+            "/admin/v2/broker-stats/metrics",
+            "/admin/broker-stats/metrics"
+    );
 
     private final TestRestTemplate testRestTemplate = new TestRestTemplate();
 
@@ -21,8 +26,13 @@ class EmbeddedPulsarHttpServiceTest extends AbstractEmbeddedPulsarTest {
 
     @Test
     void shouldCommunicateWithPulsarHttpService() {
-        URI pulsarHttpService = URI.create(pulsarServiceUrl + METRICS_PATH);
-        ResponseEntity<String> response = testRestTemplate.getForEntity(pulsarHttpService, String.class);
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        List<HttpStatusCode> statuses = METRICS_PATHS.stream()
+                .map(path -> URI.create(pulsarServiceUrl + path))
+                .map(uri -> testRestTemplate.getForEntity(uri, String.class).getStatusCode())
+                .toList();
+
+        assertThat(statuses)
+                .withFailMessage("Expected at least one Pulsar metrics endpoint to return 200 OK, but got statuses %s", statuses)
+                .contains(HttpStatus.OK);
     }
 }


### PR DESCRIPTION
### Motivation
- The Pulsar HTTP metrics endpoint can vary across image/API versions, causing flaky `EmbeddedPulsarHttpServiceTest` when the legacy path returns `404` while other endpoints are available.
- The goal is to make the test robust by probing multiple known metrics endpoints so it succeeds on different Pulsar releases.

### Description
- Replaced the single `METRICS_PATH` constant with a `List<String> METRICS_PATHS` containing `"/metrics"`, `"/admin/v2/broker-stats/metrics"`, and `"/admin/broker-stats/metrics"` in `EmbeddedPulsarHttpServiceTest`.
- Collected HTTP status codes from each candidate endpoint as `List<HttpStatusCode>` and asserted that at least one status is `200 OK`, with an explanatory failure message that includes observed statuses.
- Removed the unused `ResponseEntity` import, added `HttpStatusCode` and `List` imports, and applied formatting fixes to satisfy `spotless` checks.

### Testing
- Ran `mvn -pl embedded-pulsar -Dtest=EmbeddedPulsarHttpServiceTest,EmbeddedPulsarBootstrapConfigurationTest,EmbeddedPulsarBrokerTest test`; initial run failed `spotless:check` due to an unused import which was fixed in a follow-up edit.
- After formatting fixes the code compiled and tests were executed but runtime Testcontainers-based tests failed because no Docker daemon was available on the environment, causing application context errors (tests could not start containers).
- Summary of automated results: formatting check passed after fix, compilation passed, but Testcontainers-dependent tests failed to run due to missing Docker (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11b20836fc8327b80a2c4c792ac19b)