### PR TITLE
Start Confluent CP‑Kafka 8+ in KRaft mode (avoid ZooKeeper)

### DIFF
--- a/embedded-kafka/src/main/java/com/playtika/testcontainer/kafka/configuration/KafkaContainerConfiguration.java
+++ b/embedded-kafka/src/main/java/com/playtika/testcontainer/kafka/configuration/KafkaContainerConfiguration.java
@@ -26,6 +26,8 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.toxiproxy.ToxiproxyContainer;
+import org.testcontainers.utility.ComparableVersion;
+import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
 import java.io.IOException;
@@ -151,7 +153,10 @@ public class KafkaContainerConfiguration {
         // All properties: https://docs.confluent.io/platform/current/installation/configuration/
         // Kafka Broker properties: https://docs.confluent.io/platform/current/installation/configuration/broker-configs.html
 
-        KafkaContainer kafka = new KafkaContainer(ContainerUtils.getDockerImageName(kafkaProperties)) {
+        DockerImageName kafkaImageName = ContainerUtils.getDockerImageName(kafkaProperties);
+        boolean kraftMode = shouldUseKraft(kafkaImageName);
+
+        KafkaContainer kafka = new KafkaContainer(kafkaImageName) {
             @Override
             public String getBootstrapServers() {
                 List<String> servers = new ArrayList<>();
@@ -172,7 +177,6 @@ public class KafkaContainerConfiguration {
         }
                 .withCreateContainerCmdModifier(cmd -> cmd.withUser(kafkaProperties.getDockerUser()))
                 .withCreateContainerCmdModifier(cmd -> cmd.withHostName(KAFKA_HOST_NAME))
-                .withEmbeddedZookeeper()
                 //see: https://stackoverflow.com/questions/41868161/kafka-in-kubernetes-cluster-how-to-publish-consume-messages-from-outside-of-kub
                 //see: https://github.com/wurstmeister/kafka-docker/blob/develop/README.md
                 // order matters: external then internal since kafka.client.ClientUtils.getPlaintextBrokerEndPoints take first for simple consumers
@@ -214,12 +218,25 @@ public class KafkaContainerConfiguration {
                 .withExtraHost(KAFKA_HOST_NAME, "127.0.0.1")
                 .waitingFor(kafkaStatusCheck);
 
+        if (kraftMode) {
+            kafka.withKraft();
+        } else {
+            kafka.withEmbeddedZookeeper();
+        }
+
         kafkaFileSystemBind(kafkaProperties, kafka);
-        zookeperFileSystemBind(zookeeperProperties, kafka);
+        if (!kraftMode) {
+            zookeperFileSystemBind(zookeeperProperties, kafka);
+        }
 
         kafka = (KafkaContainer) configureCommonsAndStart(kafka, kafkaProperties, log);
         registerKafkaEnvironment(kafka, environment, kafkaProperties);
         return kafka;
+    }
+
+    private boolean shouldUseKraft(DockerImageName dockerImageName) {
+        return "confluentinc/cp-kafka".equals(dockerImageName.getUnversionedPart())
+                && new ComparableVersion(dockerImageName.getVersionPart()).isGreaterThanOrEqualTo("8.0.0");
     }
 
     private void kafkaFileSystemBind(KafkaConfigurationProperties kafkaProperties, KafkaContainer kafka) {


### PR DESCRIPTION
### Motivation
- Confluent `cp-kafka` images 8.0.0+ use KRaft and must be started without embedded ZooKeeper, while the code previously always enabled ZooKeeper causing startup/test failures.
- The change detects Confluent Kafka image coordinates and switches to KRaft mode for compatible images while preserving the existing ZooKeeper path for older images.

### Description
- Use `ContainerUtils.getDockerImageName(...)` to obtain a `DockerImageName` and added imports for `DockerImageName` and `ComparableVersion`.
- Add `shouldUseKraft(DockerImageName)` which checks for `confluentinc/cp-kafka` and version >= `8.0.0`.
- Instantiate `KafkaContainer` with the resolved `DockerImageName` and call `kafka.withKraft()` when `shouldUseKraft` returns true, otherwise call `kafka.withEmbeddedZookeeper()`.
- Only call `zookeperFileSystemBind(...)` when ZooKeeper mode is used so filesystem binds are not applied for KRaft runs.

### Testing
- Ran compilation for the modified module: `./mvnw -Dgib.disable=true -pl embedded-kafka -am -DskipTests compile` which succeeded.  (module recompiled with the new changes)
- Built the reactor modules including `embedded-kafka` with compilation: full reactor compile succeeded with the change applied.
- Attempted to run unit tests that require Docker (e.g. `testcontainers-common` / Docker-backed tests) but they cannot run in this environment because a Docker daemon is not available (`/var/run/docker.sock` missing), so Docker-dependent tests failed here; Docker‑independent compilation/tests are green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19783dc1888327ac798bc420d229b3)