### PR TITLE
fix(redis): allow Redis 8.8 config writes

### DIFF
--- a/embedded-redis/src/main/java/com/playtika/testcontainer/redis/EmbeddedRedisBootstrapConfiguration.java
+++ b/embedded-redis/src/main/java/com/playtika/testcontainer/redis/EmbeddedRedisBootstrapConfiguration.java
@@ -98,8 +98,9 @@ public class EmbeddedRedisBootstrapConfiguration {
                         .withExposedPorts(properties.getPort())
                         .withEnv("REDIS_USER", properties.getUser())
                         .withEnv("REDIS_PASSWORD", properties.getPassword())
-                        .withCopyFileToContainer(MountableFile.forHostPath(prepareRedisConf()), "/data/redis.conf")
-                        .withCopyFileToContainer(MountableFile.forHostPath(prepareNodesConf()), "/data/nodes.conf")
+                        // Redis 8.8+ drops privileges before startup and must still read/write these files.
+                        .withCopyFileToContainer(MountableFile.forHostPath(prepareRedisConf(), 0444), "/data/redis.conf")
+                        .withCopyFileToContainer(MountableFile.forHostPath(prepareNodesConf(), 0666), "/data/nodes.conf")
                         .withCommand("redis-server", "/data/redis.conf")
                         .waitingFor(redisStartupCheckStrategy)
                         .withNetworkAliases(REDIS_NETWORK_ALIAS);


### PR DESCRIPTION
### Motivation
- Renovated the default Redis image to `redis:8.8.0-alpine`, and Redis 8.8+ drops privileges during startup which can prevent the server from reading or rewriting copied config files if file modes are too restrictive.
- Ensure embedded Redis can start and operate (rewrite `nodes.conf` for clusters) when using newer Redis images by adjusting how config files are copied into the container.

### Description
- Change `EmbeddedRedisBootstrapConfiguration` to copy `redis.conf` with mode `0444` and `nodes.conf` with mode `0666` using `MountableFile.forHostPath(..., <mode>)` so Redis 8.8+ can read and rewrite files after dropping privileges.
- Add an inline comment explaining the permission change for Redis 8.8+ privilege drop behavior.
- Keep the `redis:8.8.0-alpine` default image update and documentation text intact.

### Testing
- Ran `./mvnw -pl embedded-redis -am -Dgib.disable=true -DskipTests compile --batch-mode --no-transfer-progress`, which succeeded.
- Ran `./mvnw -pl embedded-redis -Dgib.disable=true -Dtest=DisableRedisTest test --batch-mode --no-transfer-progress`, and the test passed.
- Full Docker-backed test runs could not be executed in this environment because the CI machine has no Docker daemon (`docker` not found), so tests requiring a Docker runtime were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a197d36228c83278d20a5514a83068e)