### PR TITLE
Support subscription filters in embedded-google-pubsub

### DIFF
--- a/embedded-google-pubsub/README.adoc
+++ b/embedded-google-pubsub/README.adoc
@@ -43,6 +43,9 @@ embedded.google.pubsub:
       dead-letter:
         topic: topic0
         max-attempts: 10
+    - topic: topic2
+      subscription: subscription2
+      filter: 'attributes.eventType = "ORDER_CREATED"'
 ----
 
 ==== Produces

--- a/embedded-google-pubsub/src/main/java/com/playtika/testcontainer/pubsub/PubSubResourcesGenerator.java
+++ b/embedded-google-pubsub/src/main/java/com/playtika/testcontainer/pubsub/PubSubResourcesGenerator.java
@@ -59,11 +59,11 @@ public class PubSubResourcesGenerator implements InitializingBean {
         createTopic(ts.getTopic());
 
         if (ts.getSubscription() != null) {
-            createSubscription(ts.getTopic(), ts.getSubscription(), ts.isEnableMessageOrdering(), ts.getDeadLetter());
+            createSubscription(ts.getTopic(), ts.getSubscription(), ts.isEnableMessageOrdering(), ts.getFilter(), ts.getDeadLetter());
         }
     }
 
-    public Subscription createSubscription(String topicName, String subscriptionName, boolean enableMessageOrdering, DeadLetter deadLetter) {
+    public Subscription createSubscription(String topicName, String subscriptionName, boolean enableMessageOrdering, String filter, DeadLetter deadLetter) {
         ProjectTopicName topic = ProjectTopicName.of(projectId, topicName);
         ProjectSubscriptionName subscription = ProjectSubscriptionName.of(projectId, subscriptionName);
 
@@ -75,6 +75,10 @@ public class PubSubResourcesGenerator implements InitializingBean {
                     .setTopic(topic.toString())
                     .setAckDeadlineSeconds(100)
                     .setEnableMessageOrdering(enableMessageOrdering);
+            if (filter != null && !filter.isBlank()) {
+                log.info("with filter [{}]", filter);
+                builder.setFilter(filter);
+            }
             if (deadLetter != null) {
                 log.info("with DeadLetterPolicy [topic: {}, maxAttempts: {}]", deadLetter.getTopic(), deadLetter.getMaxAttempts());
                 ProjectTopicName dlqTopic = ProjectTopicName.of(projectId, deadLetter.getTopic());

--- a/embedded-google-pubsub/src/main/java/com/playtika/testcontainer/pubsub/TopicAndSubscription.java
+++ b/embedded-google-pubsub/src/main/java/com/playtika/testcontainer/pubsub/TopicAndSubscription.java
@@ -7,6 +7,7 @@ public class TopicAndSubscription {
     private String topic;
     private String subscription;
     private boolean enableMessageOrdering;
+    private String filter;
     private DeadLetter deadLetter;
 
     @Data

--- a/embedded-google-pubsub/src/test/java/com/playtika/testcontainer/pubsub/EmbeddedPubsubBootstrapConfigurationTest.java
+++ b/embedded-google-pubsub/src/test/java/com/playtika/testcontainer/pubsub/EmbeddedPubsubBootstrapConfigurationTest.java
@@ -145,7 +145,7 @@ class EmbeddedPubsubBootstrapConfigurationTest {
 
         assertThat(unfilteredMessages)
                 .extracting(message -> message.getPubsubMessage().getData().toStringUtf8())
-                .containsExactly("non-matching", "matching");
+                .containsExactlyInAnyOrder("non-matching", "matching");
     }
 
     @Test

--- a/embedded-google-pubsub/src/test/java/com/playtika/testcontainer/pubsub/EmbeddedPubsubBootstrapConfigurationTest.java
+++ b/embedded-google-pubsub/src/test/java/com/playtika/testcontainer/pubsub/EmbeddedPubsubBootstrapConfigurationTest.java
@@ -65,6 +65,13 @@ class EmbeddedPubsubBootstrapConfigurationTest {
         assertThat(environment.getProperty("embedded.google.pubsub.topics-and-subscriptions[1].enable-message-ordering")).isEqualTo("true");
         assertThat(environment.getProperty("embedded.google.pubsub.topics-and-subscriptions[1].dead-letter.topic")).isEqualTo("topic0");
         assertThat(environment.getProperty("embedded.google.pubsub.topics-and-subscriptions[1].dead-letter.max-attempts")).isEqualTo("10");
+
+        assertThat(environment.getProperty("embedded.google.pubsub.topics-and-subscriptions[2].topic")).isEqualTo("topic2");
+        assertThat(environment.getProperty("embedded.google.pubsub.topics-and-subscriptions[2].subscription")).isEqualTo("subscription2-unfiltered");
+
+        assertThat(environment.getProperty("embedded.google.pubsub.topics-and-subscriptions[3].topic")).isEqualTo("topic2");
+        assertThat(environment.getProperty("embedded.google.pubsub.topics-and-subscriptions[3].subscription")).isEqualTo("subscription2-filtered");
+        assertThat(environment.getProperty("embedded.google.pubsub.topics-and-subscriptions[3].filter")).isEqualTo("attributes.eventType = \"CREATED\"");
     }
 
     @Test
@@ -110,22 +117,35 @@ class EmbeddedPubsubBootstrapConfigurationTest {
     }
 
     @Test
+    void shouldNotHaveFilterConfigured() {
+        ProjectSubscriptionName subscription2Unfiltered = ProjectSubscriptionName.of(projectId, "subscription2-unfiltered");
+        Subscription subscription = resourcesGenerator.getSubscription(subscription2Unfiltered);
+        assertThat(subscription.getFilter()).isEmpty();
+    }
+
+    @Test
     void shouldHaveFilterConfigured() {
-        ProjectSubscriptionName subscription2 = ProjectSubscriptionName.of(projectId, "subscription2");
-        Subscription subscription = resourcesGenerator.getSubscription(subscription2);
-        assertThat(subscription.getFilter()).isEqualTo("attributes.eventType = \"ORDER_CREATED\"");
+        ProjectSubscriptionName subscription2Filtered = ProjectSubscriptionName.of(projectId, "subscription2-filtered");
+        Subscription subscription = resourcesGenerator.getSubscription(subscription2Filtered);
+        assertThat(subscription.getFilter()).isEqualTo("attributes.eventType = \"CREATED\"");
     }
 
     @Test
     void shouldOnlyConsumeMessagesMatchingFilter() {
-        template.publish("topic2", "matching", Map.of("eventType", "ORDER_CREATED"));
         template.publish("topic2", "non-matching", Map.of("eventType", "PING"));
+        template.publish("topic2", "matching", Map.of("eventType", "CREATED"));
 
-        List<AcknowledgeablePubsubMessage> messages = template.pull("subscription2", 10, false);
+        List<AcknowledgeablePubsubMessage> filteredMessages = template.pull("subscription2-filtered", 10, false);
 
-        assertThat(messages)
+        assertThat(filteredMessages)
                 .extracting(message -> message.getPubsubMessage().getData().toStringUtf8())
                 .containsExactly("matching");
+
+        List<AcknowledgeablePubsubMessage> unfilteredMessages = template.pull("subscription2-unfiltered", 10, false);
+
+        assertThat(unfilteredMessages)
+                .extracting(message -> message.getPubsubMessage().getData().toStringUtf8())
+                .containsExactly("non-matching", "matching");
     }
 
     @Test

--- a/embedded-google-pubsub/src/test/java/com/playtika/testcontainer/pubsub/EmbeddedPubsubBootstrapConfigurationTest.java
+++ b/embedded-google-pubsub/src/test/java/com/playtika/testcontainer/pubsub/EmbeddedPubsubBootstrapConfigurationTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.containers.GenericContainer;
 
 import java.util.List;
+import java.util.Map;
 
 import static com.playtika.testcontainer.pubsub.PubsubProperties.BEAN_NAME_EMBEDDED_GOOGLE_PUBSUB;
 import static java.util.Arrays.asList;
@@ -106,6 +107,25 @@ class EmbeddedPubsubBootstrapConfigurationTest {
         List<AcknowledgeablePubsubMessage> messages = template.pull("subscription0", 1, false);
 
         assertThat(messages.size()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldHaveFilterConfigured() {
+        ProjectSubscriptionName subscription2 = ProjectSubscriptionName.of(projectId, "subscription2");
+        Subscription subscription = resourcesGenerator.getSubscription(subscription2);
+        assertThat(subscription.getFilter()).isEqualTo("attributes.eventType = \"ORDER_CREATED\"");
+    }
+
+    @Test
+    void shouldOnlyConsumeMessagesMatchingFilter() {
+        template.publish("topic2", "matching", Map.of("eventType", "ORDER_CREATED"));
+        template.publish("topic2", "non-matching", Map.of("eventType", "PING"));
+
+        List<AcknowledgeablePubsubMessage> messages = template.pull("subscription2", 10, false);
+
+        assertThat(messages)
+                .extracting(message -> message.getPubsubMessage().getData().toStringUtf8())
+                .containsExactly("matching");
     }
 
     @Test

--- a/embedded-google-pubsub/src/test/resources/bootstrap-enabled.yaml
+++ b/embedded-google-pubsub/src/test/resources/bootstrap-enabled.yaml
@@ -9,3 +9,6 @@ embedded.google.pubsub:
       dead-letter:
         topic: topic0
         max-attempts: 10
+    - topic: topic2
+      subscription: subscription2
+      filter: 'attributes.eventType = "ORDER_CREATED"'

--- a/embedded-google-pubsub/src/test/resources/bootstrap-enabled.yaml
+++ b/embedded-google-pubsub/src/test/resources/bootstrap-enabled.yaml
@@ -10,5 +10,7 @@ embedded.google.pubsub:
         topic: topic0
         max-attempts: 10
     - topic: topic2
-      subscription: subscription2
-      filter: 'attributes.eventType = "ORDER_CREATED"'
+      subscription: subscription2-unfiltered
+    - topic: topic2
+      subscription: subscription2-filtered
+      filter: 'attributes.eventType = "CREATED"'


### PR DESCRIPTION
## What

Adds support for attribute-based **subscription filters** in `embedded-google-pubsub`.

The Pub/Sub emulator [supports filtering](https://cloud.google.com/pubsub/docs/emulator) (listed under supported features), but the module had no way to configure it. This exposes a `filter` field on each topic/subscription entry, applied at subscription creation time — mirroring the existing `enable-message-ordering` and `dead-letter` configuration.

## Usage

```yaml
embedded.google.pubsub:
  topics-and-subscriptions:
    - topic: topic2
      subscription: subscription2
      filter: 'attributes.eventType = "ORDER_CREATED"'
```

## Changes

- `TopicAndSubscription` — new `filter` field
- `PubSubResourcesGenerator` — sets `filter` on the subscription when present
- `README.adoc` — documented in the example
- Tests:
  - `shouldHaveFilterConfigured` — asserts the filter is set on the created subscription
  - `shouldOnlyConsumeMessagesMatchingFilter` — publishes a matching + non-matching message and verifies only the matching one is delivered (proves the emulator actually filters)

## Checklist

- [x] Naming/formatting matches existing code
- [x] Test for success scenario
- [x] Negative scenario (autoconfiguration disabled) already covered by existing `DisablePubsubTest` (existing module)
- [x] Documentation in `README.adoc`
- N/A new module / BOM entry (change to an existing module)
- [x] No version bump in pom.xml

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for subscription message filters to deliver only messages matching filter expressions (e.g., attributes.eventType = "CREATED").

* **Documentation**
  * Examples and configuration updated to show adding both filtered and unfiltered subscriptions to topics.

* **Tests**
  * Added tests validating filtered vs. unfiltered subscription behavior and that filtered subscriptions receive only matching messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PlaytikaOSS/testcontainers-spring-boot/pull/3007?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->