### PR TITLE
docs: fix typo in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,7 +13,7 @@ A clear and concise description of what the bug is and stack trace.
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
-**Enviroment (please complete the following information):**
+**Environment (please complete the following information):**
  - OS name : [e.g. MacOS]
  - Docker Version: [e.g. 20.10.24]
 


### PR DESCRIPTION
Fixes a small spelling typo in the bug report template: `Enviroment` -> `Environment`.

This PR was made using the GitHub API without cloning the repository locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected a spelling error in the bug report template (“Environment” heading) to improve clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->