### PR TITLE
Support mongodb replica set for transaction and change stream #1182

### DIFF
--- a/embedded-mongodb/README.adoc
+++ b/embedded-mongodb/README.adoc
@@ -51,4 +51,4 @@ To auto-configure `spring-data-mongodb` use these properties in your test `appli
 spring.mongodb.uri=mongodb://${embedded.mongodb.host}:${embedded.mongodb.port}/${embedded.mongodb.database}
 ----
 
-For replicaset, add additional mongodb properties: `?rs=${embedded.mongodb.replica-set-name}&directConnection=true&authSource=admin`
+For replicaset, add additional mongodb properties: `?replicaSet=${embedded.mongodb.replica-set-name}&directConnection=true&authSource=admin`

--- a/embedded-mongodb/src/main/java/com/playtika/testcontainer/mongodb/EmbeddedMongodbBootstrapConfiguration.java
+++ b/embedded-mongodb/src/main/java/com/playtika/testcontainer/mongodb/EmbeddedMongodbBootstrapConfiguration.java
@@ -94,7 +94,6 @@ public class EmbeddedMongodbBootstrapConfiguration {
                     .withEnv("MONGO_INITDB_ROOT_USERNAME", properties.getUsername())
                     .withEnv("MONGO_INITDB_ROOT_PASSWORD", properties.getPassword())
                     .withEnv("MONGO_INITDB_DATABASE", properties.getDatabase())
-                    .withEnv("MONGO_INITDB_REPL_SET_HOST", properties.getHost())
                     .withExposedPorts(properties.getPort())
                     .waitingFor(new MongodbWaitStrategy(properties))
                     .withNetworkAliases(MONGODB_NETWORK_ALIAS);
@@ -124,7 +123,7 @@ public class EmbeddedMongodbBootstrapConfiguration {
         }
 
         log.info("Started mongodb. Connection Details: {}, Connection URI: mongodb://{}:{}/{}{}", map, host, mappedPort, properties.getDatabase(), Optional.ofNullable(
-                properties.getReplicaSetName()).map("?directConnection=true&authSource=admin&rs="::concat).orElse("")
+                properties.getReplicaSetName()).map("?directConnection=true&authSource=admin&replicaSet="::concat).orElse("")
         );
 
         MapPropertySource propertySource = new MapPropertySource("embeddedMongoInfo", map);

--- a/embedded-mongodb/src/test/java/com/playtika/testcontainer/mongodb/EmbeddedMongodbBootstrapReplicaSetConfigurationTest.java
+++ b/embedded-mongodb/src/test/java/com/playtika/testcontainer/mongodb/EmbeddedMongodbBootstrapReplicaSetConfigurationTest.java
@@ -1,20 +1,36 @@
 package com.playtika.testcontainer.mongodb;
 
 
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+import com.mongodb.client.model.changestream.ChangeStreamDocument;
+import com.mongodb.client.model.changestream.OperationType;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.bson.Document;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoTransactionManager;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Slf4j
 @SpringBootTest(
@@ -33,6 +49,9 @@ public class EmbeddedMongodbBootstrapReplicaSetConfigurationTest {
 
     @Autowired
     ConfigurableEnvironment environment;
+
+    @Autowired
+    TransactionalFooService transactionalFooService;
 
 
     @Test
@@ -54,11 +73,92 @@ public class EmbeddedMongodbBootstrapReplicaSetConfigurationTest {
         assertThat(environment.getProperty("embedded.mongodb.replica-set-name")).isNotEmpty();
     }
 
+    // Regression test for https://github.com/PlaytikaOSS/testcontainers-spring-boot/issues/1182 :
+    // on a standalone mongod, this whole flow throws
+    // "Transaction numbers are only allowed on a replica set member or mongos" before commit/rollback even applies.
+    @Test
+    public void shouldCommitTransactionAcrossMultipleDocuments() {
+        Foo foo1 = new Foo(UUID.randomUUID().toString(), "foo1", Instant.parse("2019-09-26T07:57:12.801Z"), 1L);
+        Foo foo2 = new Foo(UUID.randomUUID().toString(), "foo2", Instant.parse("2019-09-26T07:57:12.801Z"), 2L);
+
+        transactionalFooService.saveTwo(foo1, foo2);
+
+        assertThat(mongoTemplate.findById(foo1.someId(), Foo.class)).isEqualTo(foo1);
+        assertThat(mongoTemplate.findById(foo2.someId(), Foo.class)).isEqualTo(foo2);
+    }
+
+    @Test
+    public void shouldRollbackTransactionOnException() {
+        Foo foo1 = new Foo(UUID.randomUUID().toString(), "foo1", Instant.parse("2019-09-26T07:57:12.801Z"), 1L);
+        Foo foo2 = new Foo(UUID.randomUUID().toString(), "foo2", Instant.parse("2019-09-26T07:57:12.801Z"), 2L);
+
+        assertThatThrownBy(() -> transactionalFooService.saveTwoThenFail(foo1, foo2))
+                .isInstanceOf(IllegalStateException.class);
+
+        assertThat(mongoTemplate.findById(foo1.someId(), Foo.class)).isNull();
+        assertThat(mongoTemplate.findById(foo2.someId(), Foo.class)).isNull();
+    }
+
+    @Test
+    public void shouldReceiveChangeStreamEvents() throws Exception {
+        String collectionName = "changeStream-" + UUID.randomUUID();
+        mongoTemplate.createCollection(collectionName);
+        MongoCollection<Document> collection = mongoTemplate.getCollection(collectionName);
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try (MongoCursor<ChangeStreamDocument<Document>> cursor = collection.watch().iterator()) {
+            Future<ChangeStreamDocument<Document>> future = executor.submit(cursor::next);
+
+            String insertedId = UUID.randomUUID().toString();
+            collection.insertOne(new Document("_id", insertedId).append("value", "bar"));
+
+            ChangeStreamDocument<Document> event = future.get(10, TimeUnit.SECONDS);
+
+            assertThat(event.getOperationType()).isEqualTo(OperationType.INSERT);
+            assertThat(event.getFullDocument()).isNotNull();
+            assertThat(event.getFullDocument().getString("_id")).isEqualTo(insertedId);
+            assertThat(event.getFullDocument().getString("value")).isEqualTo("bar");
+        } finally {
+            executor.shutdownNow();
+            mongoTemplate.dropCollection(collectionName);
+        }
+    }
+
     record Foo(@Id String someId, String someString, Instant someTimestamp, Long someNumber) {
     }
 
+    @RequiredArgsConstructor
+    static class TransactionalFooService {
+
+        private final MongoTemplate mongoTemplate;
+
+        @Transactional
+        public void saveTwo(Foo a, Foo b) {
+            mongoTemplate.save(a);
+            mongoTemplate.save(b);
+        }
+
+        @Transactional
+        public void saveTwoThenFail(Foo a, Foo b) {
+            mongoTemplate.save(a);
+            mongoTemplate.save(b);
+            throw new IllegalStateException("boom");
+        }
+    }
+
     @EnableAutoConfiguration
+    @EnableTransactionManagement
     @Configuration
     static class TestConfiguration {
+
+        @Bean
+        MongoTransactionManager mongoTransactionManager(MongoDatabaseFactory dbFactory) {
+            return new MongoTransactionManager(dbFactory);
+        }
+
+        @Bean
+        TransactionalFooService transactionalFooService(MongoTemplate mongoTemplate) {
+            return new TransactionalFooService(mongoTemplate);
+        }
     }
 }


### PR DESCRIPTION
Motivation:

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

Modification:

Describe the modifications you've done.

Result:

Fixes #<GitHub issue number>.

If there is no issue then describe the changes introduced by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated MongoDB replica-set connection examples and logged URIs to use the standard `replicaSet` parameter.
  * Improved replica-set container configuration for more reliable connectivity.

* **Tests**
  * Added coverage for MongoDB transactions, including commits and rollbacks.
  * Added verification for change-stream events and improved test cleanup and timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->